### PR TITLE
Add (send/execute)_with_extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New methods on `ClientWithExtensions` and `RequestBuilder` for sending requests with initial extensions.

--- a/reqwest-middleware/src/client.rs
+++ b/reqwest-middleware/src/client.rs
@@ -125,6 +125,7 @@ impl ClientWithMiddleware {
         self.execute_with_extensions(req, &mut ext).await
     }
 
+    /// Executes a request with initial [`Extensions`].
     pub async fn execute_with_extensions(&self, req: Request, ext: &mut Extensions) -> Result<Response> { 
         let next = Next::new(&self.inner, &self.middleware_stack);
         next.run(req, ext).await
@@ -243,6 +244,7 @@ impl RequestBuilder {
         self.client.execute(req).await
     }
 
+    /// Sends a request with initial [`Extensions`].
     pub async fn send_with_extensions(self, ext: &mut Extensions) -> Result<Response> {
         let req = self.inner.build()?;
         self.client.execute_with_extensions(req, ext).await

--- a/reqwest-middleware/src/client.rs
+++ b/reqwest-middleware/src/client.rs
@@ -121,9 +121,13 @@ impl ClientWithMiddleware {
     /// See
     /// [`Client::execute`](https://docs.rs/reqwest/latest/reqwest/struct.Client.html#method.execute)
     pub async fn execute(&self, req: Request) -> Result<Response> {
-        let next = Next::new(&self.inner, &self.middleware_stack);
         let mut ext = Extensions::new();
-        next.run(req, &mut ext).await
+        self.execute_with_extensions(req, &mut ext).await
+    }
+
+    pub async fn execute_with_extensions(&self, req: Request, ext: &mut Extensions) -> Result<Response> { 
+        let next = Next::new(&self.inner, &self.middleware_stack);
+        next.run(req, ext).await
     }
 }
 
@@ -237,6 +241,11 @@ impl RequestBuilder {
     pub async fn send(self) -> Result<Response> {
         let req = self.inner.build()?;
         self.client.execute(req).await
+    }
+
+    pub async fn send_with_extensions(self, ext: &mut Extensions) -> Result<Response> {
+        let req = self.inner.build()?;
+        self.client.execute_with_extensions(req, ext).await
     }
 
     pub fn try_clone(self) -> Option<Self> {

--- a/reqwest-middleware/src/client.rs
+++ b/reqwest-middleware/src/client.rs
@@ -126,7 +126,11 @@ impl ClientWithMiddleware {
     }
 
     /// Executes a request with initial [`Extensions`].
-    pub async fn execute_with_extensions(&self, req: Request, ext: &mut Extensions) -> Result<Response> { 
+    pub async fn execute_with_extensions(
+        &self,
+        req: Request,
+        ext: &mut Extensions,
+    ) -> Result<Response> {
         let next = Next::new(&self.inner, &self.middleware_stack);
         next.run(req, ext).await
     }


### PR DESCRIPTION
<!-- Please explain the changes you made -->

Adds `ClientWithMiddleware::execute_with_extensions` and `RequestBuilder::send_with_extensions`.

Closes #1 

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/reqwest-middleware/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CHANGELOG.md
-->
