### PR TITLE
Reqwest default features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,5 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+- Disabled default features on `reqwest`
+
 ### Added
 - New methods on `ClientWithExtensions` and `RequestBuilder` for sending requests with initial extensions.

--- a/reqwest-middleware/Cargo.toml
+++ b/reqwest-middleware/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-middleware"
-version = "0.1.1"
+version = "0.1.2-alpha.0"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Wrapper around reqwest to allow for client middleware chains."
@@ -15,7 +15,7 @@ anyhow = "1"
 async-trait = "0.1.51"
 futures = "0.3"
 http = "0.2"
-reqwest = { version = "0.11", features = ["json", "multipart"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "multipart"] }
 serde = "1"
 thiserror = "1"
 truelayer-extensions = "0.1"

--- a/reqwest-middleware/Cargo.toml
+++ b/reqwest-middleware/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-middleware"
-version = "0.1.2-alpha.0"
+version = "0.1.1"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Wrapper around reqwest to allow for client middleware chains."

--- a/reqwest-retry/CHANGELOG.md
+++ b/reqwest-retry/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Updated `reqwest-middleware` dependency to `0.1.2-alpha.0`
 - Disabled default features on `reqwest`
 
 ## [0.1.1] - 2021-09-15

--- a/reqwest-retry/CHANGELOG.md
+++ b/reqwest-retry/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Updated `reqwest-middleware` dependency to `0.1.2-alpha.0`
+- Disabled default features on `reqwest`
+
 ## [0.1.1] - 2021-09-15
 ### Changed
 - Updated `reqwest-middleware` dependency to `0.1.1`.

--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["reqwest", "http", "middleware", "retry"]
 categories = ["web-programming::http-client"]
 
 [dependencies]
-reqwest-middleware = { version = "0.1.2-alpha.0", path = "../reqwest-middleware" }
+reqwest-middleware = { version = "0.1.1", path = "../reqwest-middleware" }
 
 anyhow = "1"
 async-trait = "0.1.51"

--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["reqwest", "http", "middleware", "retry"]
 categories = ["web-programming::http-client"]
 
 [dependencies]
-reqwest-middleware = { version = "0.1.1", path = "../reqwest-middleware" }
+reqwest-middleware = { version = "0.1.2-alpha.0", path = "../reqwest-middleware" }
 
 anyhow = "1"
 async-trait = "0.1.51"
@@ -18,7 +18,7 @@ chrono = "0.4"
 futures = "0.3"
 http = "0.2"
 retry-policies = "0.1"
-reqwest = "0.11"
+reqwest = { version = "0.11", default-features = false }
 tokio = { version = "1.6", features = ["time"] }
 tracing = "0.1.26"
 truelayer-extensions = "0.1"

--- a/reqwest-tracing/CHANGELOG.md
+++ b/reqwest-tracing/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Updated `reqwest-middleware` dependency to `0.1.2-alpha.0`
+- Disabled default features on `reqwest`
+
 ## [0.1.2] - 2021-09-15
 ### Changed
 - Updated `reqwest-middleware` dependency to `0.1.1`.

--- a/reqwest-tracing/CHANGELOG.md
+++ b/reqwest-tracing/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Updated `reqwest-middleware` dependency to `0.1.2-alpha.0`
 - Disabled default features on `reqwest`
 
 ## [0.1.2] - 2021-09-15

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -16,10 +16,10 @@ opentelemetry_0_15 = ["opentelemetry_0_15_pkg", "tracing-opentelemetry_0_14_pkg"
 opentelemetry_0_16 = ["opentelemetry_0_16_pkg", "tracing-opentelemetry_0_15_pkg"]
 
 [dependencies]
-reqwest-middleware = { version = "0.1.1", path = "../reqwest-middleware" }
+reqwest-middleware = { version = "0.1.2-alpha.0", path = "../reqwest-middleware" }
 
 async-trait = "0.1.51"
-reqwest = "0.11"
+reqwest = { version = "0.11", default-features = false }
 tokio = { version = "1.6", features = ["time"] }
 tracing = "0.1.26"
 truelayer-extensions = "0.1"

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -16,7 +16,7 @@ opentelemetry_0_15 = ["opentelemetry_0_15_pkg", "tracing-opentelemetry_0_14_pkg"
 opentelemetry_0_16 = ["opentelemetry_0_16_pkg", "tracing-opentelemetry_0_15_pkg"]
 
 [dependencies]
-reqwest-middleware = { version = "0.1.2-alpha.0", path = "../reqwest-middleware" }
+reqwest-middleware = { version = "0.1.1", path = "../reqwest-middleware" }
 
 async-trait = "0.1.51"
 reqwest = { version = "0.11", default-features = false }


### PR DESCRIPTION
<!-- Please explain the changes you made -->

Similar to #6 but it's slightly less intrusive. Disabled default features for reqwest entirely so that the consumer of these crates can decided explicitly what features to enable. It's expected that they include the `reqwest` crate in their own dependency anyway (needed to create the `ClientWithMiddleware`) so they will likely have the default dependencies enabled on their own

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/reqwest-middleware/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CHANGELOG.md
-->
