### PR TITLE
update tracing-opentelemetry to 0.16

### DIFF
--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["web-programming::http-client"]
 opentelemetry_0_13 = ["opentelemetry_0_13_pkg", "tracing-opentelemetry_0_12_pkg"]
 opentelemetry_0_14 = ["opentelemetry_0_14_pkg", "tracing-opentelemetry_0_13_pkg"]
 opentelemetry_0_15 = ["opentelemetry_0_15_pkg", "tracing-opentelemetry_0_14_pkg"]
-opentelemetry_0_16 = ["opentelemetry_0_16_pkg", "tracing-opentelemetry_0_15_pkg"]
+opentelemetry_0_16 = ["opentelemetry_0_16_pkg", "tracing-opentelemetry_0_16_pkg"]
 
 [dependencies]
 reqwest-middleware = { version = "0.1.2", path = "../reqwest-middleware" }
@@ -31,7 +31,7 @@ opentelemetry_0_16_pkg = { package = "opentelemetry", version = "0.16", optional
 tracing-opentelemetry_0_12_pkg = { package = "tracing-opentelemetry",version = "0.12", optional = true }
 tracing-opentelemetry_0_13_pkg = { package = "tracing-opentelemetry", version = "0.13", optional = true }
 tracing-opentelemetry_0_14_pkg = { package = "tracing-opentelemetry",version = "0.14", optional = true }
-tracing-opentelemetry_0_15_pkg = { package = "tracing-opentelemetry",version = "0.15", optional = true }
+tracing-opentelemetry_0_16_pkg = { package = "tracing-opentelemetry",version = "0.16", optional = true }
 
 [dev-dependencies]
 wiremock = "0.5"

--- a/reqwest-tracing/src/otel.rs
+++ b/reqwest-tracing/src/otel.rs
@@ -25,7 +25,7 @@ pub use tracing_opentelemetry_0_13_pkg as tracing_opentelemetry;
 pub use tracing_opentelemetry_0_14_pkg as tracing_opentelemetry;
 
 #[cfg(feature = "opentelemetry_0_16")]
-pub use tracing_opentelemetry_0_15_pkg as tracing_opentelemetry;
+pub use tracing_opentelemetry_0_16_pkg as tracing_opentelemetry;
 
 use opentelemetry::global;
 use opentelemetry::propagation::Injector;


### PR DESCRIPTION
fix #17 

this update requires moving to tracing-subscriber 0.3. It removes chrono
from transitive dependencies, following
https://rustsec.org/advisories/RUSTSEC-2020-0159.html

Context:
- tracing-opentelemetry 0.16 release: https://github.com/tokio-rs/tracing/pull/1682
- tracing subscriber 0.3 release with the removal of chrono: https://github.com/tokio-rs/tracing/pull/1677