### PR TITLE
Derive Debug for ClientWithMiddleware, fixes issue #20

### DIFF
--- a/reqwest-middleware/src/client.rs
+++ b/reqwest-middleware/src/client.rs
@@ -55,7 +55,7 @@ impl ClientBuilder {
 
 /// `ClientWithMiddleware` is a wrapper around [`reqwest::Client`] which runs middleware on every
 /// request.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ClientWithMiddleware {
     inner: reqwest::Client,
     middleware_stack: Box<[Arc<dyn Middleware>]>,

--- a/reqwest-middleware/src/lib.rs
+++ b/reqwest-middleware/src/lib.rs
@@ -10,6 +10,7 @@
 //! use reqwest_middleware::{ClientBuilder, Middleware, Next, Result};
 //! use task_local_extensions::Extensions;
 //!
+//! #[derive(Debug)]
 //! struct LoggingMiddleware;
 //!
 //! #[async_trait::async_trait]

--- a/reqwest-middleware/src/middleware.rs
+++ b/reqwest-middleware/src/middleware.rs
@@ -15,6 +15,7 @@ use crate::error::{Error, Result};
 /// use reqwest_middleware::{ClientBuilder, Middleware, Next, Result};
 /// use task_local_extensions::Extensions;
 ///
+/// #[derive(Debug)]
 /// struct TransparentMiddleware;
 ///
 /// #[async_trait::async_trait]
@@ -33,7 +34,7 @@ use crate::error::{Error, Result};
 /// [`ClientWithMiddleware`]: crate::ClientWithMiddleware
 /// [`with`]: crate::ClientBuilder::with
 #[async_trait::async_trait]
-pub trait Middleware: 'static + Send + Sync {
+pub trait Middleware: 'static + Send + Sync + std::fmt::Debug {
     /// Invoked with a request before sending it. If you want to continue processing the request,
     /// you should explicitly call `next.run(req, extensions)`.
     ///
@@ -52,6 +53,7 @@ impl<F> Middleware for F
 where
     F: Send
         + Sync
+        + std::fmt::Debug
         + 'static
         + for<'a> Fn(Request, &'a mut Extensions, Next<'a>) -> BoxFuture<'a, Result<Response>>,
 {

--- a/reqwest-retry/src/middleware.rs
+++ b/reqwest-retry/src/middleware.rs
@@ -35,6 +35,7 @@ static MAXIMUM_NUMBER_OF_RETRIES: u32 = 10;
 ///     let client = ClientBuilder::new(Client::new()).with(retry_transient_middleware).build();
 ///```
 ///
+#[derive(Debug)]
 pub struct RetryTransientMiddleware<T: RetryPolicy + Send + Sync + 'static> {
     retry_policy: T,
 }
@@ -47,7 +48,7 @@ impl<T: RetryPolicy + Send + Sync> RetryTransientMiddleware<T> {
 }
 
 #[async_trait::async_trait]
-impl<T: RetryPolicy + Send + Sync> Middleware for RetryTransientMiddleware<T> {
+impl<T: RetryPolicy + Send + Sync + std::fmt::Debug> Middleware for RetryTransientMiddleware<T> {
     async fn handle(
         &self,
         req: Request,

--- a/reqwest-tracing/src/middleware.rs
+++ b/reqwest-tracing/src/middleware.rs
@@ -4,6 +4,7 @@ use reqwest_middleware::{Error, Middleware, Next, Result};
 use task_local_extensions::Extensions;
 
 /// Middleware for tracing requests using the current Opentelemetry Context.
+#[derive(Debug)]
 pub struct TracingMiddleware;
 
 #[async_trait::async_trait]


### PR DESCRIPTION
Derives Debug trait for ClientWithMiddleware, and added as supertrait for Middleware. Updates examples, retry, and tracing middlewares. 