### PR TITLE
adds manual Debug implementation for ClientWithMiddleware

### DIFF
--- a/reqwest-middleware/src/client.rs
+++ b/reqwest-middleware/src/client.rs
@@ -3,7 +3,7 @@ use reqwest::multipart::Form;
 use reqwest::{Body, Client, IntoUrl, Method, Request, Response};
 use serde::Serialize;
 use std::convert::TryFrom;
-use std::fmt::Display;
+use std::fmt::{self, Display};
 use std::sync::Arc;
 use std::time::Duration;
 use task_local_extensions::Extensions;
@@ -135,6 +135,15 @@ impl From<Client> for ClientWithMiddleware {
             inner: client,
             middleware_stack: Box::new([]),
         }
+    }
+}
+
+impl fmt::Debug for ClientWithMiddleware {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // skipping middleware_stack field for now
+        f.debug_struct("ClientWithMiddleware")
+            .field("inner", &self.inner)
+            .finish()
     }
 }
 


### PR DESCRIPTION
This adds a implementation of Debug that skips the middleware_stack field to avoid breaking changes, described [here](https://github.com/TrueLayer/reqwest-middleware/pull/21#issuecomment-986632499) in PR #21 