### PR TITLE
moved to finish_non_exhaustive in Debug impl for ClientWithMiddleware

### DIFF
--- a/reqwest-middleware/src/client.rs
+++ b/reqwest-middleware/src/client.rs
@@ -143,7 +143,7 @@ impl fmt::Debug for ClientWithMiddleware {
         // skipping middleware_stack field for now
         f.debug_struct("ClientWithMiddleware")
             .field("inner", &self.inner)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 


### PR DESCRIPTION
This moves from the finish() method to the finish_non_exhaustive() method in the custom Debug impl for ClientWithMiddleware.

"Marks the struct as non-exhaustive, indicating to the reader that there are some other fields that are not shown in the debug representation." - [`DebugStruct` docs](https://doc.rust-lang.org/stable/std/fmt/struct.DebugStruct.html#method.finish_non_exhaustive)