### PR TITLE
Added a way to specify custom functions which decide whether a request should be retried or not

### DIFF
--- a/reqwest-retry/CHANGELOG.md
+++ b/reqwest-retry/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added 
+- `RetryableStrategy` which allows for custom retry decisions based on the response that a request got
 
 ## [0.2.1] - 2022-12-01
 
@@ -12,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Classify `io::Error`s and `hyper::Error(Canceled)` as transient
 
 ## [0.2.0] - 2022-11-15
-
 ### Changed
 - Updated `reqwest-middleware` to `0.2.0`
 

--- a/reqwest-retry/src/lib.rs
+++ b/reqwest-retry/src/lib.rs
@@ -27,8 +27,10 @@
 
 mod middleware;
 mod retryable;
+mod retryable_strategy;
 
 pub use retry_policies::{policies, RetryPolicy};
 
 pub use middleware::RetryTransientMiddleware;
 pub use retryable::Retryable;
+pub use retryable_strategy::RetryableStrategy;

--- a/reqwest-retry/src/lib.rs
+++ b/reqwest-retry/src/lib.rs
@@ -33,4 +33,7 @@ pub use retry_policies::{policies, RetryPolicy};
 
 pub use middleware::RetryTransientMiddleware;
 pub use retryable::Retryable;
-pub use retryable_strategy::RetryableStrategy;
+pub use retryable_strategy::{
+    default_on_request_failure, default_on_request_success, DefaultRetryableStrategy,
+    RetryableStrategy,
+};

--- a/reqwest-retry/src/middleware.rs
+++ b/reqwest-retry/src/middleware.rs
@@ -58,6 +58,17 @@ impl<T: RetryPolicy + Send + Sync> RetryTransientMiddleware<T> {
             retryable_strategy: RetryableStrategy::default(),
         }
     }
+
+    /// Construct a [`RetryTransientMiddleware`] With a given [`RetryPolicy`] and [`RetryableStrategy`]
+    pub fn new_with_retryable_strat(
+        retry_policy: T, 
+        retryable_strategy: RetryableStrategy
+    ) -> Self {
+        Self {
+            retry_policy,
+            retryable_strategy
+        }
+    }
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]

--- a/reqwest-retry/src/middleware.rs
+++ b/reqwest-retry/src/middleware.rs
@@ -61,12 +61,12 @@ impl<T: RetryPolicy + Send + Sync> RetryTransientMiddleware<T> {
 
     /// Construct a [`RetryTransientMiddleware`] With a given [`RetryPolicy`] and [`RetryableStrategy`]
     pub fn new_with_retryable_strat(
-        retry_policy: T, 
-        retryable_strategy: RetryableStrategy
+        retry_policy: T,
+        retryable_strategy: RetryableStrategy,
     ) -> Self {
         Self {
             retry_policy,
-            retryable_strategy
+            retryable_strategy,
         }
     }
 }

--- a/reqwest-retry/src/middleware.rs
+++ b/reqwest-retry/src/middleware.rs
@@ -53,12 +53,9 @@ pub struct RetryTransientMiddleware<
 }
 
 impl<T: RetryPolicy + Send + Sync> RetryTransientMiddleware<T, DefaultRetryableStrategy> {
-    /// Construct `RetryTransientMiddleware` with  a [retry_policy][retry_policies::RetryPolicy].
+    /// Construct `RetryTransientMiddleware` with  a [retry_policy][RetryPolicy].
     pub fn new_with_policy(retry_policy: T) -> Self {
-        Self {
-            retry_policy,
-            retryable_strategy: DefaultRetryableStrategy,
-        }
+        Self::new_with_policy_and_strategy(retry_policy, DefaultRetryableStrategy)
     }
 }
 
@@ -67,7 +64,7 @@ where
     T: RetryPolicy + Send + Sync,
     R: RetryableStrategy + Send + Sync,
 {
-    /// Construct `RetryTransientMiddleware` with  a [retry_policy][retry_policies::RetryPolicy].
+    /// Construct `RetryTransientMiddleware` with  a [retry_policy][RetryPolicy] and [retryable_strategy](RetryableStrategy).
     pub fn new_with_policy_and_strategy(retry_policy: T, retryable_strategy: R) -> Self {
         Self {
             retry_policy,

--- a/reqwest-retry/src/middleware.rs
+++ b/reqwest-retry/src/middleware.rs
@@ -46,12 +46,16 @@ use task_local_extensions::Extensions;
 /// source directly, avoiding the issue of streaming requests not being clonable.
 pub struct RetryTransientMiddleware<T: RetryPolicy + Send + Sync + 'static> {
     retry_policy: T,
+    retryable_from_resp: fn(&Result<reqwest::Response, >) -> Option<Retryable>,
 }
 
 impl<T: RetryPolicy + Send + Sync> RetryTransientMiddleware<T> {
     /// Construct `RetryTransientMiddleware` with  a [retry_policy][retry_policies::RetryPolicy].
     pub fn new_with_policy(retry_policy: T) -> Self {
-        Self { retry_policy }
+        Self { 
+            retry_policy,
+            retryable_from_resp: Retryable::from_reqwest_response,
+        }
     }
 }
 
@@ -98,7 +102,7 @@ impl<T: RetryPolicy + Send + Sync> RetryTransientMiddleware<T> {
 
             // We classify the response which will return None if not
             // errors were returned.
-            break match Retryable::from_reqwest_response(&result) {
+            break match (self.retryable_from_resp)(&result) {
                 Some(Retryable::Transient) => {
                     // If the response failed and the error type was transient
                     // we can safely try to retry the request.

--- a/reqwest-retry/src/retryable.rs
+++ b/reqwest-retry/src/retryable.rs
@@ -1,4 +1,4 @@
-use crate::retryable_strategy::RetryableStrategy;
+use crate::retryable_strategy::{DefaultRetryableStrategy, RetryableStrategy};
 use reqwest_middleware::Error;
 
 /// Classification of an error/status returned by request.
@@ -16,7 +16,7 @@ impl Retryable {
     /// Returns `None` if the response object does not contain any errors.
     ///
     pub fn from_reqwest_response(res: &Result<reqwest::Response, Error>) -> Option<Self> {
-        RetryableStrategy::default().handle(res)
+        DefaultRetryableStrategy.handle(res)
     }
 }
 

--- a/reqwest-retry/src/retryable.rs
+++ b/reqwest-retry/src/retryable.rs
@@ -1,4 +1,4 @@
-use http::StatusCode;
+use crate::retryable_strategy::RetryableStrategy;
 use reqwest_middleware::Error;
 
 /// Classification of an error/status returned by request.
@@ -16,78 +16,7 @@ impl Retryable {
     /// Returns `None` if the response object does not contain any errors.
     ///
     pub fn from_reqwest_response(res: &Result<reqwest::Response, Error>) -> Option<Self> {
-        match res {
-            Ok(success) => {
-                let status = success.status();
-                if status.is_server_error() {
-                    Some(Retryable::Transient)
-                } else if status.is_client_error()
-                    && status != StatusCode::REQUEST_TIMEOUT
-                    && status != StatusCode::TOO_MANY_REQUESTS
-                {
-                    Some(Retryable::Fatal)
-                } else if status.is_success() {
-                    None
-                } else if status == StatusCode::REQUEST_TIMEOUT
-                    || status == StatusCode::TOO_MANY_REQUESTS
-                {
-                    Some(Retryable::Transient)
-                } else {
-                    Some(Retryable::Fatal)
-                }
-            }
-            Err(error) => match error {
-                // If something fails in the middleware we're screwed.
-                Error::Middleware(_) => Some(Retryable::Fatal),
-                Error::Reqwest(error) => {
-                    #[cfg(not(target_arch = "wasm32"))]
-                    let is_connect = error.is_connect();
-                    #[cfg(target_arch = "wasm32")]
-                    let is_connect = false;
-                    if error.is_timeout() || is_connect {
-                        Some(Retryable::Transient)
-                    } else if error.is_body()
-                        || error.is_decode()
-                        || error.is_builder()
-                        || error.is_redirect()
-                    {
-                        Some(Retryable::Fatal)
-                    } else if error.is_request() {
-                        // It seems that hyper::Error(IncompleteMessage) is not correctly handled by reqwest.
-                        // Here we check if the Reqwest error was originated by hyper and map it consistently.
-                        #[cfg(not(target_arch = "wasm32"))]
-                        if let Some(hyper_error) = get_source_error_type::<hyper::Error>(&error) {
-                            // The hyper::Error(IncompleteMessage) is raised if the HTTP response is well formatted but does not contain all the bytes.
-                            // This can happen when the server has started sending back the response but the connection is cut halfway thorugh.
-                            // We can safely retry the call, hence marking this error as [`Retryable::Transient`].
-                            // Instead hyper::Error(Canceled) is raised when the connection is
-                            // gracefully closed on the server side.
-                            if hyper_error.is_incomplete_message() || hyper_error.is_canceled() {
-                                Some(Retryable::Transient)
-
-                            // Try and downcast the hyper error to io::Error if that is the
-                            // underlying error, and try and classify it.
-                            } else if let Some(io_error) =
-                                get_source_error_type::<std::io::Error>(hyper_error)
-                            {
-                                Some(classify_io_error(io_error))
-                            } else {
-                                Some(Retryable::Fatal)
-                            }
-                        } else {
-                            Some(Retryable::Fatal)
-                        }
-                        #[cfg(target_arch = "wasm32")]
-                        Some(Retryable::Fatal)
-                    } else {
-                        // We omit checking if error.is_status() since we check that already.
-                        // However, if Response::error_for_status is used the status will still
-                        // remain in the response object.
-                        None
-                    }
-                }
-            },
-        }
+        RetryableStrategy::default().handle(res)
     }
 }
 
@@ -95,31 +24,4 @@ impl From<&reqwest::Error> for Retryable {
     fn from(_status: &reqwest::Error) -> Retryable {
         Retryable::Transient
     }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn classify_io_error(error: &std::io::Error) -> Retryable {
-    match error.kind() {
-        std::io::ErrorKind::ConnectionReset | std::io::ErrorKind::ConnectionAborted => {
-            Retryable::Transient
-        }
-        _ => Retryable::Fatal,
-    }
-}
-
-/// Downcasts the given err source into T.
-#[cfg(not(target_arch = "wasm32"))]
-fn get_source_error_type<T: std::error::Error + 'static>(
-    err: &dyn std::error::Error,
-) -> Option<&T> {
-    let mut source = err.source();
-
-    while let Some(err) = source {
-        if let Some(hyper_err) = err.downcast_ref::<T>() {
-            return Some(hyper_err);
-        }
-
-        source = err.source();
-    }
-    None
 }

--- a/reqwest-retry/src/retryable_strategy.rs
+++ b/reqwest-retry/src/retryable_strategy.rs
@@ -1,0 +1,164 @@
+use crate::retryable::Retryable;
+use http::StatusCode;
+use reqwest_middleware::Error;
+
+/// A strategy to create a [`Retryable`] from a [`Result<reqwest::Response, reqwest_middleware::Error>`]
+///
+/// A [`RetryableStrategy`] has two functions, a `success_handler` and a `error_handler`
+/// The correct handler will be called based on what the result of calling the request was.
+/// The result of calling the request could be:\
+/// - [`reqwest::Response`] In case the request has been sent and received correctly
+///     This could however still mean that the server responded with a erroneous response.
+///     For example a HTTP statuscode of 500
+/// - [`reqwest_middleware::Error`] In this case the request actually failed.
+///     This could, for example, be caused by a timeout on the connection.
+pub struct RetryableStrategy {
+    pub success_handler: fn(&reqwest::Response) -> Option<Retryable>,
+    pub error_handler: fn(&Error) -> Option<Retryable>,
+}
+
+impl Default for RetryableStrategy {
+    /// The default strategy to use to convert a [`reqwest::Response`] to a retry decision
+    fn default() -> Self {
+        Self {
+            success_handler: Self::default_success_handler,
+            error_handler: Self::default_error_handler,
+        }
+    }
+}
+
+impl RetryableStrategy {
+    /// Actually classifies the request as a [`Retryable`],
+    /// based on the success- and error-handlers for this [`RetryableStrategy`]
+    pub fn handle(&self, res: &Result<reqwest::Response, Error>) -> Option<Retryable> {
+        match res {
+            Ok(success) => (self.success_handler)(success),
+            Err(error) => (self.error_handler)(error),
+        }
+    }
+
+    pub fn new(
+        success_handler: Option<fn(&reqwest::Response) -> Option<Retryable>>,
+        error_handler: Option<fn(&Error) -> Option<Retryable>>,
+    ) -> Self {
+        // Choose default success_handler if the passed argument is `None`
+        let success_handler = if let Some(x) = success_handler {
+            x
+        } else {
+            Self::default_success_handler
+        };
+
+        // Choose default error_handler if the passed argument is `None`
+        let error_handler = if let Some(x) = error_handler {
+            x
+        } else {
+            Self::default_error_handler
+        };
+
+        Self {
+            success_handler,
+            error_handler,
+        }
+    }
+
+    /// A good default handler for a success response
+    pub fn default_success_handler(success: &reqwest::Response) -> Option<Retryable> {
+        let status = success.status();
+        if status.is_server_error() {
+            Some(Retryable::Transient)
+        } else if status.is_client_error()
+            && status != StatusCode::REQUEST_TIMEOUT
+            && status != StatusCode::TOO_MANY_REQUESTS
+        {
+            Some(Retryable::Fatal)
+        } else if status.is_success() {
+            None
+        } else if status == StatusCode::REQUEST_TIMEOUT || status == StatusCode::TOO_MANY_REQUESTS {
+            Some(Retryable::Transient)
+        } else {
+            Some(Retryable::Fatal)
+        }
+    }
+
+    /// A good default handler for a failed response
+    pub fn default_error_handler(error: &Error) -> Option<Retryable> {
+        match error {
+            // If something fails in the middleware we're screwed.
+            Error::Middleware(_) => Some(Retryable::Fatal),
+            Error::Reqwest(error) => {
+                #[cfg(not(target_arch = "wasm32"))]
+                let is_connect = error.is_connect();
+                #[cfg(target_arch = "wasm32")]
+                let is_connect = false;
+                if error.is_timeout() || is_connect {
+                    Some(Retryable::Transient)
+                } else if error.is_body()
+                    || error.is_decode()
+                    || error.is_builder()
+                    || error.is_redirect()
+                {
+                    Some(Retryable::Fatal)
+                } else if error.is_request() {
+                    // It seems that hyper::Error(IncompleteMessage) is not correctly handled by reqwest.
+                    // Here we check if the Reqwest error was originated by hyper and map it consistently.
+                    #[cfg(not(target_arch = "wasm32"))]
+                    if let Some(hyper_error) = get_source_error_type::<hyper::Error>(&error) {
+                        // The hyper::Error(IncompleteMessage) is raised if the HTTP response is well formatted but does not contain all the bytes.
+                        // This can happen when the server has started sending back the response but the connection is cut halfway thorugh.
+                        // We can safely retry the call, hence marking this error as [`Retryable::Transient`].
+                        // Instead hyper::Error(Canceled) is raised when the connection is
+                        // gracefully closed on the server side.
+                        if hyper_error.is_incomplete_message() || hyper_error.is_canceled() {
+                            Some(Retryable::Transient)
+
+                        // Try and downcast the hyper error to io::Error if that is the
+                        // underlying error, and try and classify it.
+                        } else if let Some(io_error) =
+                            get_source_error_type::<std::io::Error>(hyper_error)
+                        {
+                            Some(classify_io_error(io_error))
+                        } else {
+                            Some(Retryable::Fatal)
+                        }
+                    } else {
+                        Some(Retryable::Fatal)
+                    }
+                    #[cfg(target_arch = "wasm32")]
+                    Some(Retryable::Fatal)
+                } else {
+                    // We omit checking if error.is_status() since we check that already.
+                    // However, if Response::error_for_status is used the status will still
+                    // remain in the response object.
+                    None
+                }
+            }
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn classify_io_error(error: &std::io::Error) -> Retryable {
+    match error.kind() {
+        std::io::ErrorKind::ConnectionReset | std::io::ErrorKind::ConnectionAborted => {
+            Retryable::Transient
+        }
+        _ => Retryable::Fatal,
+    }
+}
+
+/// Downcasts the given err source into T.
+#[cfg(not(target_arch = "wasm32"))]
+fn get_source_error_type<T: std::error::Error + 'static>(
+    err: &dyn std::error::Error,
+) -> Option<&T> {
+    let mut source = err.source();
+
+    while let Some(err) = source {
+        if let Some(hyper_err) = err.downcast_ref::<T>() {
+            return Some(hyper_err);
+        }
+
+        source = err.source();
+    }
+    None
+}

--- a/reqwest-retry/src/retryable_strategy.rs
+++ b/reqwest-retry/src/retryable_strategy.rs
@@ -12,18 +12,18 @@ use reqwest_middleware::Error;
 ///     For example a HTTP statuscode of 500
 /// - [`reqwest_middleware::Error`] In this case the request actually failed.
 ///     This could, for example, be caused by a timeout on the connection.
-/// 
+///
 /// Example:
-/// 
+///
 /// ```
 /// use reqwest_retry::{RetryableStrategy, policies::ExponentialBackoff, RetryTransientMiddleware, Retryable};
 /// use reqwest::{Request, Response};
 /// use reqwest_middleware::{ClientBuilder, Middleware, Next, Result};
 /// use task_local_extensions::Extensions;
-/// 
+///
 /// // Log each request to show that the requests will be retried
 /// struct LoggingMiddleware;
-/// 
+///
 /// #[async_trait::async_trait]
 /// impl Middleware for LoggingMiddleware {
 ///     async fn handle(
@@ -38,7 +38,7 @@ use reqwest_middleware::Error;
 ///         res
 ///     }
 /// }
-/// 
+///
 /// // Just a toy example, retry when the response code is 201, else do nothing.
 /// fn retry_201(res: &reqwest::Response) -> Option<Retryable> {
 ///     if res.status() == 201 {
@@ -47,8 +47,8 @@ use reqwest_middleware::Error;
 ///         None
 ///     }
 /// }
-/// 
-/// 
+///
+///
 /// #[tokio::main]
 /// async fn main() {
 ///     // Create the retry stategy. Success responses will be handled by `retry_201`.
@@ -57,7 +57,7 @@ use reqwest_middleware::Error;
 ///         Some(retry_201),
 ///         None
 ///     );
-/// 
+///
 ///     // Exponential backoff with max 2 retries
 ///     let retry_policy = ExponentialBackoff::builder()
 ///         .build_with_max_retries(2);
@@ -67,21 +67,21 @@ use reqwest_middleware::Error;
 ///         retry_policy,
 ///         ret_strat
 ///     );
-/// 
+///
 ///     let client = ClientBuilder::new(reqwest::Client::new())
 ///         // Retry failed requests.
 ///         .with(ret_s)
 ///         // Log the requests
 ///         .with(LoggingMiddleware)
 ///         .build();
-/// 
+///
 ///     // Send request which should get a 201 response. So it will be retried
 ///     let r = client   
 ///         .get("https://httpbin.org/status/201")
 ///         .send()
 ///         .await;
 ///     println!("{:?}", r);
-/// 
+///
 ///     // Send request which should get a 200 response. So it will not be retried
 ///     let r = client   
 ///         .get("https://httpbin.org/status/200")

--- a/reqwest-retry/src/retryable_strategy.rs
+++ b/reqwest-retry/src/retryable_strategy.rs
@@ -4,9 +4,8 @@ use reqwest_middleware::Error;
 
 /// A strategy to create a [`Retryable`] from a [`Result<reqwest::Response, reqwest_middleware::Error>`]
 ///
-/// A [`RetryableStrategy`] has two functions, a `success_handler` and a `error_handler`
-/// The correct handler will be called based on what the result of calling the request was.
-/// The result of calling the request could be:\
+/// A [`RetryableStrategy`] has a single `handler` functions.
+/// The result of calling the request could be:
 /// - [`reqwest::Response`] In case the request has been sent and received correctly
 ///     This could however still mean that the server responded with a erroneous response.
 ///     For example a HTTP statuscode of 500
@@ -44,8 +43,11 @@ use reqwest_middleware::Error;
 /// impl RetryableStrategy for Retry201 {
 ///     fn handle(&self, res: &Result<reqwest::Response>) -> Option<Retryable> {
 ///          match res {
+///              // retry if 201
 ///              Ok(success) if success.status() == 201 => Some(Retryable::Transient),
+///              // otherwise do not retry a successful request
 ///              Ok(success) => None,
+///              // but maybe retry a request failure
 ///              Err(error) => default_on_request_failure(error),
 ///         }
 ///     }


### PR DESCRIPTION
Added functionality that allows you to specify custom functions that will direct whether a request will be retried or not. 

The implementation doesn't interfere with the already existing API. 

## Added
A `RetryableStrategy` trait, much like the `SpanBackend` trait for `TracingMiddleware`.

Default handlers are added for both success and error. (those are the results of splitting the original `Retryable::from_reqwest_response` function)

Added a function `new_with_policy_and_strategy` on `RetryTransientMiddleware` that takes a `RetryableStrategy` which will be used to decide whether a request should be retried.