### PR TITLE
Update `otel.status_code` mapping with latest version of spec.

### DIFF
--- a/reqwest-tracing/CHANGELOG.md
+++ b/reqwest-tracing/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix how we set the OpenTelemetry span status, based on the HTTP response status.
+
 # [0.2.2] - 2022-04-21
 ### Fixed
 - Opentelemetry context is now propagated when the request span is disabled.


### PR DESCRIPTION
I may have misunderstood the intention of the existing implementation, but I think this is more aligned with [what the semantic conventions specify](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#status).