### PR TITLE
bump reqwest-tracing to v0.2.3

### DIFF
--- a/reqwest-middleware/Cargo.toml
+++ b/reqwest-middleware/Cargo.toml
@@ -17,12 +17,12 @@ futures = "0.3"
 http = "0.2"
 reqwest = { version = "0.11", default-features = false, features = ["json", "multipart"] }
 serde = "1"
-thiserror = "1"
 task-local-extensions = "0.1.1"
+thiserror = "1"
 
 [dev-dependencies]
 reqwest = "0.11"
 reqwest-retry = { path = "../reqwest-retry" }
 reqwest-tracing = { path = "../reqwest-tracing" }
-wiremock = "0.5"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+wiremock = "0.5"

--- a/reqwest-middleware/Cargo.toml
+++ b/reqwest-middleware/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-middleware"
-version = "0.1.7"
+version = "0.1.7-alpha.0"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Wrapper around reqwest to allow for client middleware chains."

--- a/reqwest-middleware/Cargo.toml
+++ b/reqwest-middleware/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-middleware"
-version = "0.1.7-alpha.0"
+version = "0.1.7"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Wrapper around reqwest to allow for client middleware chains."

--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["reqwest", "http", "middleware", "retry"]
 categories = ["web-programming::http-client"]
 
 [dependencies]
-reqwest-middleware = { version = "^0.1.6" }
+reqwest-middleware = { version = "^0.1.6", path = "../reqwest-middleware" }
 
 anyhow = "1"
 async-trait = "0.1.51"

--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["reqwest", "http", "middleware", "retry"]
 categories = ["web-programming::http-client"]
 
 [dependencies]
-reqwest-middleware = { version = "^0.1.7-alpha.0", path = "../reqwest-middleware" }
+reqwest-middleware = { version = "^0.1.6" }
 
 anyhow = "1"
 async-trait = "0.1.51"

--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-retry"
-version = "0.1.6"
+version = "0.1.6-alpha.0"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Retry middleware for reqwest."
@@ -10,7 +10,7 @@ keywords = ["reqwest", "http", "middleware", "retry"]
 categories = ["web-programming::http-client"]
 
 [dependencies]
-reqwest-middleware = { version = "^0.1.6", path = "../reqwest-middleware" }
+reqwest-middleware = { version = "^0.1.6" }
 
 anyhow = "1"
 async-trait = "0.1.51"

--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-retry"
-version = "0.1.6-alpha.0"
+version = "0.1.6"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Retry middleware for reqwest."

--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -18,14 +18,14 @@ chrono = { version = "0.4.19", features = ["clock"], default-features = false }
 futures = "0.3"
 http = "0.2"
 hyper = "0.14"
-retry-policies = "0.1"
 reqwest = { version = "0.11", default-features = false }
+retry-policies = "0.1"
+task-local-extensions = "0.1.1"
 tokio = { version = "1.6", features = ["time"] }
 tracing = "0.1.26"
-task-local-extensions = "0.1.1"
 
 [dev-dependencies]
-wiremock = "0.5"
-tokio = { version = "1", features = ["macros"] }
-paste = "1"
 async-std = { version = "1.10"}
+paste = "1"
+tokio = { version = "1", features = ["macros"] }
+wiremock = "0.5"

--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["reqwest", "http", "middleware", "retry"]
 categories = ["web-programming::http-client"]
 
 [dependencies]
-reqwest-middleware = { version = "^0.1.7", path = "../reqwest-middleware" }
+reqwest-middleware = { version = "^0.1.6", path = "../reqwest-middleware" }
 
 anyhow = "1"
 async-trait = "0.1.51"

--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["reqwest", "http", "middleware", "retry"]
 categories = ["web-programming::http-client"]
 
 [dependencies]
-reqwest-middleware = { version = "^0.1.6", path = "../reqwest-middleware" }
+reqwest-middleware = { version = "^0.1.7-alpha.0", path = "../reqwest-middleware" }
 
 anyhow = "1"
 async-trait = "0.1.51"

--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["reqwest", "http", "middleware", "retry"]
 categories = ["web-programming::http-client"]
 
 [dependencies]
-reqwest-middleware = { version = "^0.1.6", path = "../reqwest-middleware" }
+reqwest-middleware = { version = "^0.1.7", path = "../reqwest-middleware" }
 
 anyhow = "1"
 async-trait = "0.1.51"

--- a/reqwest-tracing/CHANGELOG.md
+++ b/reqwest-tracing/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2022-06-23
 ### Fixed
 - Fix how we set the OpenTelemetry span status, based on the HTTP response status.
 

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -18,7 +18,7 @@ opentelemetry_0_17 = ["opentelemetry_0_17_pkg", "tracing-opentelemetry_0_17_pkg"
 
 
 [dependencies]
-reqwest-middleware = { version = "^0.1.6", path = "../reqwest-middleware"}
+reqwest-middleware = { version = "^0.1.6" }
 
 async-trait = "0.1.51"
 reqwest = { version = "0.11", default-features = false }

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-tracing"
-version = "0.2.3-alpha.0"
+version = "0.2.3"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Opentracing middleware for reqwest."

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -18,7 +18,7 @@ opentelemetry_0_17 = ["opentelemetry_0_17_pkg", "tracing-opentelemetry_0_17_pkg"
 
 
 [dependencies]
-reqwest-middleware = { version = "^0.1.7", path = "../reqwest-middleware" }
+reqwest-middleware = { version = "^0.1.6", path = "../reqwest-middleware" }
 
 async-trait = "0.1.51"
 reqwest = { version = "0.11", default-features = false }

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -18,7 +18,7 @@ opentelemetry_0_17 = ["opentelemetry_0_17_pkg", "tracing-opentelemetry_0_17_pkg"
 
 
 [dependencies]
-reqwest-middleware = { version = "^0.1.6", path = "../reqwest-middleware" }
+reqwest-middleware = { version = "^0.1.7", path = "../reqwest-middleware" }
 
 async-trait = "0.1.51"
 reqwest = { version = "0.11", default-features = false }

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -18,7 +18,7 @@ opentelemetry_0_17 = ["opentelemetry_0_17_pkg", "tracing-opentelemetry_0_17_pkg"
 
 
 [dependencies]
-reqwest-middleware = { version = "^0.1.6" }
+reqwest-middleware = { version = "^0.1.6", path = "../reqwest-middleware"}
 
 async-trait = "0.1.51"
 reqwest = { version = "0.11", default-features = false }

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -18,7 +18,7 @@ opentelemetry_0_17 = ["opentelemetry_0_17_pkg", "tracing-opentelemetry_0_17_pkg"
 
 
 [dependencies]
-reqwest-middleware = { version = "^0.1.6", path = "../reqwest-middleware" }
+reqwest-middleware = { version = "^0.1.6" }
 
 async-trait = "0.1.51"
 reqwest = { version = "0.11", default-features = false }

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -22,9 +22,9 @@ reqwest-middleware = { version = "^0.1.7", path = "../reqwest-middleware" }
 
 async-trait = "0.1.51"
 reqwest = { version = "0.11", default-features = false }
+task-local-extensions = "0.1.1"
 tokio = { version = "1.6", features = ["time"] }
 tracing = "0.1.26"
-task-local-extensions = "0.1.1"
 
 opentelemetry_0_13_pkg = { package = "opentelemetry", version = "0.13", optional = true }
 opentelemetry_0_14_pkg = { package = "opentelemetry", version = "0.14", optional = true }
@@ -39,7 +39,7 @@ tracing-opentelemetry_0_17_pkg = { package = "tracing-opentelemetry",version = "
 
 
 [dev-dependencies]
-wiremock = "0.5"
 tokio = { version = "1", features = ["macros"] }
 tracing_subscriber_0_2 = { package = "tracing-subscriber", version = "0.2" }
 tracing_subscriber_0_3 = { package = "tracing-subscriber", version = "0.3" }
+wiremock = "0.5"


### PR DESCRIPTION
bumps libs releasing changes to  reqwest-tracing:
- Fix how we set the OpenTelemetry span status, based on the HTTP response status.

