### PR TITLE
Bump for next development 

### DIFF
--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["reqwest", "http", "middleware", "retry"]
 categories = ["web-programming::http-client"]
 
 [dependencies]
-reqwest-middleware = { version = "^0.1.6" }
+reqwest-middleware = { version = "0.1.7-alpha.0", path = "../reqwest-middleware" }
 
 anyhow = "1"
 async-trait = "0.1.51"

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-tracing"
-version = "0.3.0"
+version = "0.3.1-alpha.0"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Opentracing middleware for reqwest."
@@ -18,7 +18,7 @@ opentelemetry_0_17 = ["opentelemetry_0_17_pkg", "tracing-opentelemetry_0_17_pkg"
 
 
 [dependencies]
-reqwest-middleware = { version = "^0.1.6" }
+reqwest-middleware = { version = "0.1.7-alpha.0", path = "../reqwest-middleware" }
 
 async-trait = "0.1.51"
 reqwest = { version = "0.11", default-features = false }


### PR DESCRIPTION
Bumps `request-tracing` to v0.3.1-alpha.0.
Updateds `cargo.toml` files to use `reqwest-middlewarev0.1.7-alpha.0`.

