### PR TITLE
Add note about streaming requests in RetryTransientMiddleware docs

### DIFF
--- a/reqwest-retry/src/middleware.rs
+++ b/reqwest-retry/src/middleware.rs
@@ -35,6 +35,18 @@ static MAXIMUM_NUMBER_OF_RETRIES: u32 = 10;
 ///     let client = ClientBuilder::new(Client::new()).with(retry_transient_middleware).build();
 ///```
 ///
+/// # Note
+///
+/// This middleware always errors when given requests with streaming bodies, before even executing
+/// the request. When this happens you'll get an [`Error::Middleware`] with the message
+/// 'Request object is not clonable. Are you passing a streaming body?'.
+///
+/// Some workaround suggestions:
+/// * If you can fit the data in memory, you can instead build static request bodies e.g. with
+/// `Body`'s `From<String>` or `From<Bytes>` implementations.
+/// * You can wrap this middleware in a custom one which skips retries for streaming requests.
+/// * You can write a custom retry middleware that builds new streaming requests from the data
+/// source directly, avoiding the issue of streaming requests not being clonable.
 pub struct RetryTransientMiddleware<T: RetryPolicy + Send + Sync + 'static> {
     retry_policy: T,
 }


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/reqwest-middleware/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CHANGELOG.md
-->

Prompted by #44, added docs about `RetryTransientMiddleware` not supporting streaming requests