### PR TITLE
Http-compliance

### DIFF
--- a/reqwest-tracing/CHANGELOG.md
+++ b/reqwest-tracing/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+ - Require an explicit otel name in the macros. Reduces cardinality and complies
+   with otel specification for HTTP bindings.
 
 ## [0.3.1] - 2022-09-21
 - Added support for `opentelemetry` version `0.18`.

--- a/reqwest-tracing/src/lib.rs
+++ b/reqwest-tracing/src/lib.rs
@@ -49,8 +49,8 @@ pub use middleware::TracingMiddleware;
 pub use reqwest_otel_span_builder::{
     default_on_request_end, default_on_request_failure, default_on_request_success,
     DefaultSpanBackend, ReqwestOtelSpanBackend, ERROR_CAUSE_CHAIN, ERROR_MESSAGE, HTTP_HOST,
-    HTTP_METHOD, HTTP_SCHEME, HTTP_STATUS_CODE, HTTP_USER_AGENT, NET_HOST_PORT, OTEL_KIND,
-    OTEL_NAME, OTEL_STATUS_CODE,
+    HTTP_METHOD, HTTP_SCHEME, HTTP_STATUS_CODE, HTTP_URL, HTTP_USER_AGENT, NET_HOST_PORT,
+    OTEL_KIND, OTEL_NAME, OTEL_STATUS_CODE,
 };
 
 #[doc(hidden)]

--- a/reqwest-tracing/src/lib.rs
+++ b/reqwest-tracing/src/lib.rs
@@ -19,7 +19,7 @@
 //! impl ReqwestOtelSpanBackend for TimeTrace {
 //!     fn on_request_start(req: &Request, extension: &mut Extensions) -> Span {
 //!         extension.insert(Instant::now());
-//!         reqwest_otel_span!(req, time_elapsed = tracing::field::Empty)
+//!         reqwest_otel_span!(name="example-request", req, time_elapsed = tracing::field::Empty)
 //!     }
 //!
 //!     fn on_request_end(span: &Span, outcome: &Result<Response>, extension: &mut Extensions) {

--- a/reqwest-tracing/src/middleware.rs
+++ b/reqwest-tracing/src/middleware.rs
@@ -6,6 +6,7 @@ use tracing::Instrument;
 use crate::{DefaultSpanBackend, ReqwestOtelSpanBackend};
 
 /// Middleware for tracing requests using the current Opentelemetry Context.
+#[derive(Clone)]
 pub struct TracingMiddleware<S: ReqwestOtelSpanBackend> {
     span_backend: std::marker::PhantomData<S>,
 }
@@ -21,12 +22,6 @@ impl<S: ReqwestOtelSpanBackend> TracingMiddleware<S> {
 impl Default for TracingMiddleware<DefaultSpanBackend> {
     fn default() -> Self {
         TracingMiddleware::new()
-    }
-}
-
-impl<S: ReqwestOtelSpanBackend> Clone for TracingMiddleware<S> {
-    fn clone(&self) -> Self {
-        Self::new()
     }
 }
 

--- a/reqwest-tracing/src/reqwest_otel_span_builder.rs
+++ b/reqwest-tracing/src/reqwest_otel_span_builder.rs
@@ -12,14 +12,16 @@ pub const HTTP_METHOD: &str = "http.method";
 pub const HTTP_SCHEME: &str = "http.scheme";
 /// The `http.host` field added to the span by [`reqwest_otel_span`]
 pub const HTTP_HOST: &str = "http.host";
+/// The `http.url` field added to the span by [`reqwest_otel_span`]
+pub const HTTP_URL: &str = "http.url";
 /// The `host.port` field added to the span by [`reqwest_otel_span`]
 pub const NET_HOST_PORT: &str = "net.host.port";
 /// The `otel.kind` field added to the span by [`reqwest_otel_span`]
 pub const OTEL_KIND: &str = "otel.kind";
 /// The `otel.name` field added to the span by [`reqwest_otel_span`]
 pub const OTEL_NAME: &str = "otel.name";
-/// The `otel.status.code` field added to the span by [`reqwest_otel_span`]
-pub const OTEL_STATUS_CODE: &str = "otel.status_code";
+/// The `otel.status_code.code` field added to the span by [`reqwest_otel_span`]
+pub const OTEL_STATUS_CODE: &str = "http.status_code";
 /// The `error.message` field added to the span by [`reqwest_otel_span`]
 pub const ERROR_MESSAGE: &str = "error.message";
 /// The `error.cause_chain` field added to the span by [`reqwest_otel_span`]

--- a/reqwest-tracing/src/reqwest_otel_span_builder.rs
+++ b/reqwest-tracing/src/reqwest_otel_span_builder.rs
@@ -93,7 +93,7 @@ pub struct DefaultSpanBackend;
 
 impl ReqwestOtelSpanBackend for DefaultSpanBackend {
     fn on_request_start(req: &Request, _: &mut Extensions) -> Span {
-        reqwest_otel_span!(req)
+        reqwest_otel_span!(name = "reqwest-http-client", req)
     }
 
     fn on_request_end(span: &Span, outcome: &Result<Response>, _: &mut Extensions) {

--- a/reqwest-tracing/src/reqwest_otel_span_macro.rs
+++ b/reqwest-tracing/src/reqwest_otel_span_macro.rs
@@ -26,7 +26,8 @@
 ///
 /// # Macro syntax
 ///
-/// The first argument passed to [`reqwest_otel_span!`] is a reference to an [`reqwest::Request`].
+/// The first argument is a [span name](https://opentelemetry.io/docs/reference/specification/trace/api/#span).
+/// The second argument passed to [`reqwest_otel_span!`] is a reference to an [`reqwest::Request`].
 ///
 /// ```rust
 /// use reqwest_middleware::Result;
@@ -41,7 +42,7 @@
 ///
 /// impl ReqwestOtelSpanBackend for CustomReqwestOtelSpanBackend {
 ///     fn on_request_start(req: &Request, _extension: &mut Extensions) -> Span {
-///         reqwest_otel_span!(req)
+///         reqwest_otel_span!(name = "reqwest-http-request", req)
 ///     }
 ///
 ///     fn on_request_end(span: &Span, outcome: &Result<Response>, _extension: &mut Extensions) {
@@ -60,17 +61,17 @@
 /// # let request: &reqwest::Request = todo!();
 ///
 /// // Define a `time_elapsed` field as empty. It might be populated later.
-/// reqwest_otel_span!(request, time_elapsed = tracing::field::Empty);
+/// reqwest_otel_span!(name = "reqwest-http-request", request, time_elapsed = tracing::field::Empty);
 ///
 /// // Define a `name` field with a known value, `AppName`.
-/// reqwest_otel_span!(request, name = "AppName");
+/// reqwest_otel_span!(name = "reqwest-http-request", request, name = "AppName");
 ///
 /// // Define an `app_id` field using the variable with the same name as value.
 /// let app_id = "XYZ";
-/// reqwest_otel_span!(request, app_id);
+/// reqwest_otel_span!(name = "reqwest-http-request", request, app_id);
 ///
 /// // All together
-/// reqwest_otel_span!(request, time_elapsed = tracing::field::Empty, name = "AppName", app_id);
+/// reqwest_otel_span!(name = "reqwest-http-request", request, time_elapsed = tracing::field::Empty, name = "AppName", app_id);
 /// ```
 ///
 /// You can also choose to customise the level of the generated span:
@@ -87,8 +88,8 @@
 ///     Level::INFO
 /// };
 ///
-/// // `level =` MUST be the first argument.
-/// reqwest_otel_span!(level = level, request);
+/// // `level =` and name MUST come before the request, in this order
+/// reqwest_otel_span!(level = level, name = "reqwest-http-request", request);
 /// ```
 ///
 ///
@@ -98,27 +99,26 @@
 /// [`default_on_request_end`]: crate::reqwest_otel_span_builder::default_on_request_end
 macro_rules! reqwest_otel_span {
     // Vanilla root span at default INFO level, with no additional fields
-    ($request:ident) => {
-        reqwest_otel_span!($request,)
+    (name=$name:expr, $request:ident) => {
+        reqwest_otel_span!(name=$name, $request,)
     };
     // Vanilla root span, with no additional fields but custom level
-    (level=$level:expr, $request:ident) => {
-        reqwest_otel_span!(level=$level, $request,)
+    (level=$level:expr, name=$name:expr, $request:ident) => {
+        reqwest_otel_span!(level=$level, name=$name, $request,)
     };
     // Root span with additional fields, default INFO level
-    ($request:ident, $($field:tt)*) => {
-        reqwest_otel_span!(level=$crate::reqwest_otel_span_macro::private::Level::INFO, $request, $($field)*)
+    (name=$name:expr, $request:ident, $($field:tt)*) => {
+        reqwest_otel_span!(level=$crate::reqwest_otel_span_macro::private::Level::INFO, name=$name, $request, $($field)*)
     };
     // Root span with additional fields and custom level
-    (level=$level:expr, $request:ident, $($field:tt)*) => {
+    (level=$level:expr, name=$name:expr, $request:ident, $($field:tt)*) => {
         {
             let method = $request.method();
             let url = $request.url();
             let scheme = url.scheme();
             let host = url.host_str().unwrap_or("");
             let host_port = url.port().unwrap_or(0) as i64;
-            let path = url.path();
-            let otel_name = format!("{} {}", method, path);
+            let otel_name = format!("{}", $name);
 
             macro_rules! request_span {
                 ($lvl:expr) => {

--- a/reqwest-tracing/src/reqwest_otel_span_macro.rs
+++ b/reqwest-tracing/src/reqwest_otel_span_macro.rs
@@ -113,10 +113,11 @@ macro_rules! reqwest_otel_span {
     (level=$level:expr, $request:ident, $($field:tt)*) => {
         {
             let method = $request.method();
-            let scheme = $request.url().scheme();
-            let host = $request.url().host_str().unwrap_or("");
-            let host_port = $request.url().port().unwrap_or(0) as i64;
-            let path = $request.url().path();
+            let url = $request.url();
+            let scheme = url.scheme();
+            let host = url.host_str().unwrap_or("");
+            let host_port = url.port().unwrap_or(0) as i64;
+            let path = url.path();
             let otel_name = format!("{} {}", method, path);
 
             macro_rules! request_span {
@@ -127,6 +128,7 @@ macro_rules! reqwest_otel_span {
                         http.method = %method,
                         http.scheme = %scheme,
                         http.host = %host,
+                        http.url = %url,
                         net.host.port = %host_port,
                         otel.kind = "client",
                         otel.name = %otel_name,


### PR DESCRIPTION
Closes: #52

This is suggested by the Opentelemetry spec, which requires "Therefore,
HTTP client spans SHOULD be using conservative, low cardinality names
formed from the available parameters of an HTTP request, such as "HTTP
{METHOD_NAME}". Instrumentation MUST NOT default to using URI path as
span name, but MAY provide hooks to allow custom logic to override the
default span name.
"

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/reqwest-middleware/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CHANGELOG.md
-->
