### PR TITLE
Borrow self when try_clone and clone inner client.

### DIFF
--- a/reqwest-middleware/src/client.rs
+++ b/reqwest-middleware/src/client.rs
@@ -253,8 +253,8 @@ impl RequestBuilder {
         self.client.execute_with_extensions(req, ext).await
     }
 
-    pub fn try_clone(self) -> Option<Self> {
-        let client = self.client;
+    pub fn try_clone(&self) -> Option<Self> {
+        let client = self.client.clone();
         self.inner
             .try_clone()
             .map(|inner| RequestBuilder { inner, client })


### PR DESCRIPTION
<!-- Please explain the changes you made -->

try_clone moves self and effectively destroy it which defeats the purpose of cloning. It should instead borrow self and also clone the client inside it and return a new RequestBuilder.

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/reqwest-middleware/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CHANGELOG.md
-->
