### PR TITLE
Add missing dep in reqwest-tracing README

### DIFF
--- a/reqwest-tracing/README.md
+++ b/reqwest-tracing/README.md
@@ -25,6 +25,7 @@ tokio = { version = "1.12.0", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-opentelemetry = "0.18"
 tracing-subscriber = "0.3"
+task-local-extensions = "0.1.0"
 ```
 
 ```rust,skip


### PR DESCRIPTION
Just add the missing `task-local-extensions` dependency that are required to run the code in the README. 