### PR TITLE
feat: classify io error connection reset by peer

### DIFF
--- a/reqwest-retry/CHANGELOG.md
+++ b/reqwest-retry/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2022-12-01
+
+### Changed
+- Classify `io::Error`s and `hyper::Error(Canceled)` as transient
+
 ## [0.2.0] - 2022-11-15
 
 ### Changed

--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-retry"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Retry middleware for reqwest."

--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -29,3 +29,4 @@ async-std = { version = "1.10"}
 paste = "1"
 tokio = { version = "1", features = ["macros"] }
 wiremock = "0.5"
+futures = "0.3"

--- a/reqwest-retry/src/retryable.rs
+++ b/reqwest-retry/src/retryable.rs
@@ -1,4 +1,4 @@
-use std::{error::Error as StdError, io};
+use std::io;
 
 use http::StatusCode;
 use reqwest_middleware::Error;

--- a/reqwest-retry/src/retryable.rs
+++ b/reqwest-retry/src/retryable.rs
@@ -57,6 +57,8 @@ impl Retryable {
                             // The hyper::Error(IncompleteMessage) is raised if the HTTP response is well formatted but does not contain all the bytes.
                             // This can happen when the server has started sending back the response but the connection is cut halfway thorugh.
                             // We can safely retry the call, hence marking this error as [`Retryable::Transient`].
+                            // Instead hyper::Error(Canceled) is raised when the connection is
+                            // gracefully closed on the server side.
                             if hyper_error.is_incomplete_message() || hyper_error.is_canceled() {
                                 Some(Retryable::Transient)
 

--- a/reqwest-retry/src/retryable.rs
+++ b/reqwest-retry/src/retryable.rs
@@ -97,8 +97,7 @@ fn try_io_error(error: &hyper::Error) -> Option<&io::Error> {
     // is IO here, but hyper::Error does not expose it.
     error
         .source()
-        .map(|err| err.downcast_ref::<io::Error>())
-        .flatten()
+        .and_then(|err| err.downcast_ref::<io::Error>())
 }
 
 /// Downcasts the given err source into T.

--- a/reqwest-retry/src/retryable.rs
+++ b/reqwest-retry/src/retryable.rs
@@ -59,8 +59,11 @@ impl Retryable {
                             // We can safely retry the call, hence marking this error as [`Retryable::Transient`].
                             if hyper_error.is_incomplete_message() || hyper_error.is_canceled() {
                                 Some(Retryable::Transient)
+
+                            // Try and downcast the hyper error to io::Error if that is the
+                            // underlying error, and try and classify it.
                             } else if let Some(io_error) = try_io_error(hyper_error) {
-                                Some(classify_io_error(&io_error))
+                                Some(classify_io_error(io_error))
                             } else {
                                 Some(Retryable::Fatal)
                             }

--- a/reqwest-retry/src/retryable.rs
+++ b/reqwest-retry/src/retryable.rs
@@ -62,7 +62,9 @@ impl Retryable {
 
                             // Try and downcast the hyper error to io::Error if that is the
                             // underlying error, and try and classify it.
-                            } else if let Some(io_error) = try_io_error(hyper_error) {
+                            } else if let Some(io_error) =
+                                get_source_error_type::<io::Error>(hyper_error)
+                            {
                                 Some(classify_io_error(io_error))
                             } else {
                                 Some(Retryable::Fatal)
@@ -93,14 +95,6 @@ fn classify_io_error(error: &io::Error) -> Retryable {
         io::ErrorKind::ConnectionReset | io::ErrorKind::ConnectionAborted => Retryable::Transient,
         _ => Retryable::Fatal,
     }
-}
-
-fn try_io_error(error: &hyper::Error) -> Option<&io::Error> {
-    // We would prefer being able to check that the error kind
-    // is IO here, but hyper::Error does not expose it.
-    error
-        .source()
-        .and_then(|err| err.downcast_ref::<io::Error>())
 }
 
 /// Downcasts the given err source into T.

--- a/reqwest-retry/tests/all/helpers/simple_server.rs
+++ b/reqwest-retry/tests/all/helpers/simple_server.rs
@@ -6,6 +6,10 @@ use futures::stream::StreamExt;
 use std::error::Error;
 use std::fmt;
 
+type CustomMessageHandler = Box<
+    dyn Fn(TcpStream) -> BoxFuture<'static, Result<(), Box<dyn std::error::Error>>> + Send + Sync,
+>;
+
 /// This is a simple server that returns the responses given at creation time: [`self.raw_http_responses`] following a round-robin mechanism.
 pub struct SimpleServer {
     listener: TcpListener,
@@ -13,13 +17,7 @@ pub struct SimpleServer {
     host: String,
     raw_http_responses: Vec<String>,
     calls_counter: usize,
-    custom_handler: Option<
-        Box<
-            dyn Fn(TcpStream) -> BoxFuture<'static, Result<(), Box<dyn std::error::Error>>>
-                + Send
-                + Sync,
-        >,
-    >,
+    custom_handler: Option<CustomMessageHandler>,
 }
 
 /// Request-Line = Method SP Request-URI SP HTTP-Version CRLF

--- a/reqwest-retry/tests/all/retry.rs
+++ b/reqwest-retry/tests/all/retry.rs
@@ -286,6 +286,7 @@ async fn assert_retry_on_hyper_canceled() {
             let mut buffer = Vec::new();
             stream.read(&mut buffer).await.unwrap();
             if counter.fetch_add(1, Ordering::SeqCst) > 1 {
+                // This triggeres hyper:Error(Canceled).
                 let _res = stream.shutdown(std::net::Shutdown::Both);
             } else {
                 let _res = stream.write("HTTP/1.1 200 OK\r\n\r\n".as_bytes()).await;
@@ -333,6 +334,7 @@ async fn assert_retry_on_connection_reset_by_peer() {
             let mut buffer = Vec::new();
             stream.read(&mut buffer).await.unwrap();
             if counter.fetch_add(1, Ordering::SeqCst) > 1 {
+                // This triggeres hyper:Error(Io, io::Error(ConnectionReset)).
                 drop(stream);
             } else {
                 let _res = stream.write("HTTP/1.1 200 OK\r\n\r\n".as_bytes()).await;


### PR DESCRIPTION
Tries to downcast the hyper error in order to classify the underlying io::Error when the hyper::ErrorKind is IO.
This allows us to catch when we get `Connection reset by peer` and retry it.
