### PR TITLE
Bump tokio to 1.25.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ reqwest = "0.11"
 reqwest-middleware = "0.1.6"
 reqwest-retry = "0.1.5"
 reqwest-tracing = "0.2.3"
-tokio = { version = "1.12.0", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.25", features = ["macros", "rt-multi-thread"] }
 ```
 
 ```rust

--- a/reqwest-middleware/Cargo.toml
+++ b/reqwest-middleware/Cargo.toml
@@ -16,7 +16,7 @@ async-trait = "0.1.51"
 http = "0.2"
 reqwest = { version = "0.11", default-features = false, features = ["json", "multipart"] }
 serde = "1"
-task-local-extensions = "0.1.1"
+task-local-extensions = "0.1.3"
 thiserror = "1"
 
 [dev-dependencies]

--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -20,8 +20,8 @@ http = "0.2"
 hyper = "0.14"
 reqwest = { version = "0.11", default-features = false }
 retry-policies = "0.1"
-task-local-extensions = "0.1.1"
-tokio = { version = "1.6", features = ["time"] }
+task-local-extensions = "0.1.3"
+tokio = { version = "1", features = ["time"] }
 tracing = "0.1.26"
 
 [dev-dependencies]

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -23,7 +23,7 @@ reqwest-middleware = { version = "0.2.0", path = "../reqwest-middleware" }
 
 async-trait = "0.1.51"
 reqwest = { version = "0.11", default-features = false }
-task-local-extensions = "0.1.1"
+task-local-extensions = "0.1.3"
 tracing = "0.1.26"
 
 opentelemetry_0_13_pkg = { package = "opentelemetry", version = "0.13", optional = true }

--- a/reqwest-tracing/README.md
+++ b/reqwest-tracing/README.md
@@ -21,11 +21,11 @@ reqwest = "0.11"
 reqwest-middleware = "0.1.1"
 reqwest-retry = "0.1.1"
 reqwest-tracing = { version = "0.3.1", features = ["opentelemetry_0_18"] }
-tokio = { version = "1.12.0", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.25", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-opentelemetry = "0.18"
 tracing-subscriber = "0.3"
-task-local-extensions = "0.1.0"
+task-local-extensions = "0.1.3"
 ```
 
 ```rust,skip


### PR DESCRIPTION
1.24.1 and below has a narrow problem c.f. https://osv.dev/vulnerability/RUSTSEC-2023-0005

note `task-local-extensions` also depends on `tokio`, so sneaking updates to that at the same time.