### PR TITLE
Adds support for wasm32 target

### DIFF
--- a/reqwest-middleware/src/client.rs
+++ b/reqwest-middleware/src/client.rs
@@ -239,6 +239,7 @@ impl RequestBuilder {
         }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn timeout(self, timeout: Duration) -> Self {
         RequestBuilder {
             inner: self.inner.timeout(timeout),


### PR DESCRIPTION
Since wasm32 is current single-threaded in the browser, futures do not require (and do not implement) the Send and Sync traits. This applies to reqwest. For that reason, it is necessary to add some conditionals to detect wasm32 building and disable any Send and Sync type constraints to get things to work.

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/reqwest-middleware/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CHANGELOG.md
-->
