### PR TITLE
feat: Improve retry functionality and logging in `reqwest-retry` midd…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Support to configure max retries in RetryTransientMiddleware
+- Added support to configure max retries in RetryTransientMiddleware
 
 ## [0.2.1] - 2023-03-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -6,20 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Support to configure max retries in RetryTransientMiddleware
+
 ## [0.2.1] - 2023-03-09
 
 ### Added
+
 - Support for `wasm32-unknown-unknown`
 
 ## [0.2.0] - 2022-11-15
 
 ### Changed
+
 - `RequestBuilder::try_clone` has a fixed function signature now
 
 ### Removed
+
 - `RequestBuilder::send_with_extensions` - use `RequestBuilder::with_extensions` + `RequestBuilder::send` instead.
 
 ### Added
+
 - Implementation of `Debug` trait for `RequestBuilder`.
 - A new `RequestInitialiser` trait that can be added to `ClientWithMiddleware`
 - A new `Extension` initialiser that adds extensions to each request
@@ -32,26 +39,34 @@ Absolutely nothing changed
 ## [0.1.5] - 2022-02-21
 
 ### Added
+
 - Added support for `opentelemetry` version `0.17`.
 
 ## [0.1.4] - 2022-01-24
 
 ### Changed
+
 - Made `Debug` impl for `ClientWithExtensions` non-exhaustive.
 
 ## [0.1.3] - 2021-10-18
 
 ### Security
+
 - remove time v0.1 dependency
 
 ### Fixed
+
 - Handle the `hyper::Error(IncompleteMessage)` as a `Retryable::Transient`.
 
 ## [0.1.2] - 2021-09-28
+
 ### Changed
+
 - Disabled default features on `reqwest`
 - Replaced `truelayer-extensions` with `task-local-extensions`
 
 ## [0.1.1]
+
 ### Added
+
 - New methods on `ClientWithExtensions` and `RequestBuilder` for sending requests with initial extensions.


### PR DESCRIPTION
<!-- Please explain the changes you made -->

Added support to configure max retries in the RetryTransientMiddleware. In my use case, I was running into an issue where I needed to retry more than 10 times (I'm using my own retry policy that's not an exponential backoff, so I run into the max limit quickly). 

- Add constructor for `RetryTransientMiddleware` with max retries parameter
- Fix typo
- updated changelog 
