### PR TITLE
fix: remove middleware retry limit

### DIFF
--- a/reqwest-retry/tests/all/retry.rs
+++ b/reqwest-retry/tests/all/retry.rs
@@ -151,17 +151,6 @@ assert_retry_succeeds!(429, StatusCode::OK);
 assert_no_retry!(431, StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE);
 assert_no_retry!(451, StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS);
 
-// We assert that we cap retries at 10, which means that we will
-// get 11 calls to the RetryResponder.
-assert_retry_succeeds_inner!(
-    500,
-    assert_maximum_retries_is_not_exceeded,
-    StatusCode::INTERNAL_SERVER_ERROR,
-    100,
-    11,
-    RetryResponder::new(100_u32, 500)
-);
-
 pub struct RetryTimeoutResponder(Arc<AtomicU32>, u32, std::time::Duration);
 
 impl RetryTimeoutResponder {


### PR DESCRIPTION
Removed retry limit:

- Remove MAXIMUM_NUMBER_OF_RETRIES metadata and references in middleware.rs
- Correct mispelling: retry_decision to retry_decision in middleware.rs
- Update Retryable matching to only match Retryable::Transient in middleware.rs
- Simplify branching by removing n_past_retries < MAXIMUM_NUMBER_OF_RETRIES condition in middleware.rs

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/reqwest-middleware/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CHANGELOG.md
-->
