### PR TITLE
Added version function to RequestBuilder impl

### DIFF
--- a/reqwest-middleware/src/client.rs
+++ b/reqwest-middleware/src/client.rs
@@ -210,6 +210,7 @@ impl RequestBuilder {
         }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn version(self, version: reqwest::Version) -> Self {
         RequestBuilder {
             inner: self.inner.version(version),

--- a/reqwest-middleware/src/client.rs
+++ b/reqwest-middleware/src/client.rs
@@ -210,6 +210,13 @@ impl RequestBuilder {
         }
     }
 
+    pub fn version(self, version: reqwest::Version) -> Self {
+        RequestBuilder {
+            inner: self.inner.version(version),
+            ..self
+        }
+    }
+
     pub fn basic_auth<U, P>(self, username: U, password: Option<P>) -> Self
     where
         U: Display,


### PR DESCRIPTION
Addresses an issue where the Http version of a request cannot be changed when using reqwest_middleware.