### PR TITLE
Move path matching changes to right log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `RequestBuilder::version` method to configure the HTTP version
-- `OtelPathNames` extension to provide known parameterized paths that will be used in span names
-
-### Changed
-- `DefaultSpanBackend` and `SpanBackendWithUrl` default span name to HTTP method name instead of `reqwest-http-client`
 
 ## [0.2.1] - 2023-03-09
 

--- a/reqwest-tracing/CHANGELOG.md
+++ b/reqwest-tracing/CHANGELOG.md
@@ -6,11 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2023-05-12
+
 ### Added
 - `OtelPathNames` extension to provide known parameterized paths that will be used in span names
 
 ### Changed
 - `DefaultSpanBackend` and `SpanBackendWithUrl` default span name to HTTP method name instead of `reqwest-http-client`
+
+## [0.4.1] - 2023-03-09
+
+### Added
+
+- Support for `wasm32-unknown-unknown` target
 
 ## [0.4.0] - 2022-11-15
 

--- a/reqwest-tracing/CHANGELOG.md
+++ b/reqwest-tracing/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `OtelPathNames` extension to provide known parameterized paths that will be used in span names
+
+### Changed
+- `DefaultSpanBackend` and `SpanBackendWithUrl` default span name to HTTP method name instead of `reqwest-http-client`
+
 ## [0.4.0] - 2022-11-15
 
 ### Changed

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-tracing"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Opentracing middleware for reqwest."


### PR DESCRIPTION
<!-- Please explain the changes you made -->
The changes were added to the reqwest-middleware change log but are in reqwest-tracing. This moves them to the unreleased reqwest-tracing changes.
<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/reqwest-middleware/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CHANGELOG.md
-->
