### PR TITLE
add default_span_name helper function

### DIFF
--- a/reqwest-tracing/CHANGELOG.md
+++ b/reqwest-tracing/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4] - 2023-05-15
+
+### Added
+- A new `default_span_name` method for use in custom span backends.
+
 ## [0.4.3] - 2023-05-15
 
 ### Fixed

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-tracing"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Opentracing middleware for reqwest."

--- a/reqwest-tracing/src/lib.rs
+++ b/reqwest-tracing/src/lib.rs
@@ -96,9 +96,10 @@ mod reqwest_otel_span_builder;
 pub use middleware::TracingMiddleware;
 pub use reqwest_otel_span_builder::{
     default_on_request_end, default_on_request_failure, default_on_request_success,
-    DefaultSpanBackend, OtelName, OtelPathNames, ReqwestOtelSpanBackend, SpanBackendWithUrl,
-    ERROR_CAUSE_CHAIN, ERROR_MESSAGE, HTTP_HOST, HTTP_METHOD, HTTP_SCHEME, HTTP_STATUS_CODE,
-    HTTP_URL, HTTP_USER_AGENT, NET_HOST_PORT, OTEL_KIND, OTEL_NAME, OTEL_STATUS_CODE,
+    default_span_name, DefaultSpanBackend, OtelName, OtelPathNames, ReqwestOtelSpanBackend,
+    SpanBackendWithUrl, ERROR_CAUSE_CHAIN, ERROR_MESSAGE, HTTP_HOST, HTTP_METHOD, HTTP_SCHEME,
+    HTTP_STATUS_CODE, HTTP_URL, HTTP_USER_AGENT, NET_HOST_PORT, OTEL_KIND, OTEL_NAME,
+    OTEL_STATUS_CODE,
 };
 
 #[doc(hidden)]


### PR DESCRIPTION
Custom span backends currently need to re-implement this span name logic themselves. This fixes that
