### PR TITLE
disable context propagation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           - opentelemetry_0_16
           - opentelemetry_0_17
           - opentelemetry_0_18
-          - opentelemetry_0_19
+          # - opentelemetry_0_19
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           - opentelemetry_0_16
           - opentelemetry_0_17
           - opentelemetry_0_18
+          - opentelemetry_0_19
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -44,6 +45,7 @@ jobs:
           - opentelemetry_0_16
           - opentelemetry_0_17
           - opentelemetry_0_18
+          - opentelemetry_0_19
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -90,6 +92,7 @@ jobs:
           - opentelemetry_0_16
           - opentelemetry_0_17
           - opentelemetry_0_18
+          - opentelemetry_0_19
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -118,6 +121,7 @@ jobs:
           - opentelemetry_0_16
           - opentelemetry_0_17
           - opentelemetry_0_18
+          - opentelemetry_0_19
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           - opentelemetry_0_16
           - opentelemetry_0_17
           - opentelemetry_0_18
-          # - opentelemetry_0_19
+          - opentelemetry_0_19
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/reqwest-tracing/CHANGELOG.md
+++ b/reqwest-tracing/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - A new extension `DisableOtelPropagation` which stops opentelemetry contexts propagating
+- Support for opentelemetry 0.19
 
 ## [0.4.4] - 2023-05-15
 

--- a/reqwest-tracing/CHANGELOG.md
+++ b/reqwest-tracing/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.5] - 2023-06-20
+
+### Added
+- A new extension `DisableOtelPropagation` which stops opentelemetry contexts propagating
+
 ## [0.4.4] - 2023-05-15
 
 ### Added

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-tracing"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Opentracing middleware for reqwest."

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -10,7 +10,6 @@ keywords = ["reqwest", "http", "middleware", "opentelemetry", "tracing"]
 categories = ["web-programming::http-client"]
 
 [features]
-default = ["opentelemetry_0_18"]
 opentelemetry_0_13 = ["opentelemetry_0_13_pkg", "tracing-opentelemetry_0_12_pkg"]
 opentelemetry_0_14 = ["opentelemetry_0_14_pkg", "tracing-opentelemetry_0_13_pkg"]
 opentelemetry_0_15 = ["opentelemetry_0_15_pkg", "tracing-opentelemetry_0_14_pkg"]

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -10,12 +10,14 @@ keywords = ["reqwest", "http", "middleware", "opentelemetry", "tracing"]
 categories = ["web-programming::http-client"]
 
 [features]
+default = ["opentelemetry_0_18"]
 opentelemetry_0_13 = ["opentelemetry_0_13_pkg", "tracing-opentelemetry_0_12_pkg"]
 opentelemetry_0_14 = ["opentelemetry_0_14_pkg", "tracing-opentelemetry_0_13_pkg"]
 opentelemetry_0_15 = ["opentelemetry_0_15_pkg", "tracing-opentelemetry_0_14_pkg"]
 opentelemetry_0_16 = ["opentelemetry_0_16_pkg", "tracing-opentelemetry_0_16_pkg"]
 opentelemetry_0_17 = ["opentelemetry_0_17_pkg", "tracing-opentelemetry_0_17_pkg"]
 opentelemetry_0_18 = ["opentelemetry_0_18_pkg", "tracing-opentelemetry_0_18_pkg"]
+opentelemetry_0_19 = ["opentelemetry_0_19_pkg", "tracing-opentelemetry_0_19_pkg"]
 
 
 [dependencies]
@@ -34,12 +36,14 @@ opentelemetry_0_15_pkg = { package = "opentelemetry", version = "0.15.0", option
 opentelemetry_0_16_pkg = { package = "opentelemetry", version = "0.16.0", optional = true }
 opentelemetry_0_17_pkg = { package = "opentelemetry", version = "0.17.0", optional = true }
 opentelemetry_0_18_pkg = { package = "opentelemetry", version = "0.18.0", optional = true }
+opentelemetry_0_19_pkg = { package = "opentelemetry", version = "0.19.0", optional = true }
 tracing-opentelemetry_0_12_pkg = { package = "tracing-opentelemetry",version = "0.12.0", optional = true }
 tracing-opentelemetry_0_13_pkg = { package = "tracing-opentelemetry", version = "0.13.0", optional = true }
 tracing-opentelemetry_0_14_pkg = { package = "tracing-opentelemetry",version = "0.14.0", optional = true }
 tracing-opentelemetry_0_16_pkg = { package = "tracing-opentelemetry",version = "0.16.0", optional = true }
 tracing-opentelemetry_0_17_pkg = { package = "tracing-opentelemetry",version = "0.17.0", optional = true }
 tracing-opentelemetry_0_18_pkg = { package = "tracing-opentelemetry",version = "0.18.0", optional = true }
+tracing-opentelemetry_0_19_pkg = { package = "tracing-opentelemetry",version = "0.19.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.0", features = ["js"] }

--- a/reqwest-tracing/src/lib.rs
+++ b/reqwest-tracing/src/lib.rs
@@ -90,16 +90,17 @@ mod middleware;
     feature = "opentelemetry_0_16",
     feature = "opentelemetry_0_17",
     feature = "opentelemetry_0_18",
+    feature = "opentelemetry_0_19",
 ))]
 mod otel;
 mod reqwest_otel_span_builder;
 pub use middleware::TracingMiddleware;
 pub use reqwest_otel_span_builder::{
     default_on_request_end, default_on_request_failure, default_on_request_success,
-    default_span_name, DefaultSpanBackend, OtelName, OtelPathNames, ReqwestOtelSpanBackend,
-    SpanBackendWithUrl, ERROR_CAUSE_CHAIN, ERROR_MESSAGE, HTTP_HOST, HTTP_METHOD, HTTP_SCHEME,
-    HTTP_STATUS_CODE, HTTP_URL, HTTP_USER_AGENT, NET_HOST_PORT, OTEL_KIND, OTEL_NAME,
-    OTEL_STATUS_CODE,
+    default_span_name, DefaultSpanBackend, DisableOtelPropagation, OtelName, OtelPathNames,
+    ReqwestOtelSpanBackend, SpanBackendWithUrl, ERROR_CAUSE_CHAIN, ERROR_MESSAGE, HTTP_HOST,
+    HTTP_METHOD, HTTP_SCHEME, HTTP_STATUS_CODE, HTTP_URL, HTTP_USER_AGENT, NET_HOST_PORT,
+    OTEL_KIND, OTEL_NAME, OTEL_STATUS_CODE,
 };
 
 #[doc(hidden)]

--- a/reqwest-tracing/src/middleware.rs
+++ b/reqwest-tracing/src/middleware.rs
@@ -3,7 +3,7 @@ use reqwest_middleware::{Middleware, Next, Result};
 use task_local_extensions::Extensions;
 use tracing::Instrument;
 
-use crate::{DefaultSpanBackend, ReqwestOtelSpanBackend};
+use crate::{DefaultSpanBackend, DisableOtelPropagation, ReqwestOtelSpanBackend};
 
 /// Middleware for tracing requests using the current Opentelemetry Context.
 pub struct TracingMiddleware<S: ReqwestOtelSpanBackend> {
@@ -38,15 +38,13 @@ where
 {
     async fn handle(
         &self,
-        req: Request,
+        mut req: Request,
         extensions: &mut Extensions,
         next: Next<'_>,
     ) -> Result<Response> {
         let request_span = ReqwestOtelSpan::on_request_start(&req, extensions);
 
         let outcome_future = async {
-            // Adds tracing headers to the given request to propagate the OpenTelemetry context to downstream revivers of the request.
-            // Spans added by downstream consumers will be part of the same trace.
             #[cfg(any(
                 feature = "opentelemetry_0_13",
                 feature = "opentelemetry_0_14",
@@ -54,8 +52,13 @@ where
                 feature = "opentelemetry_0_16",
                 feature = "opentelemetry_0_17",
                 feature = "opentelemetry_0_18",
+                feature = "opentelemetry_0_19",
             ))]
-            let req = crate::otel::inject_opentelemetry_context_into_request(req);
+            if !extensions.contains::<DisableOtelPropagation>() {
+                // Adds tracing headers to the given request to propagate the OpenTelemetry context to downstream revivers of the request.
+                // Spans added by downstream consumers will be part of the same trace.
+                req = crate::otel::inject_opentelemetry_context_into_request(req);
+            }
 
             // Run the request
             let outcome = next.run(req, extensions).await;

--- a/reqwest-tracing/src/reqwest_otel_span_builder.rs
+++ b/reqwest-tracing/src/reqwest_otel_span_builder.rs
@@ -276,6 +276,41 @@ impl OtelPathNames {
     }
 }
 
+/// `DisableOtelPropagation` disables opentelemetry header propagation, while still tracing the HTTP request.
+///
+/// By default, the [`TracingMiddleware`](super::TracingMiddleware) middleware will also propagate any opentelemtry
+/// contexts to the server. For any external facing requests, this can be problematic and it should be disabled.
+///
+/// Usage:
+/// ```no_run
+/// # use reqwest_middleware::Result;
+/// use reqwest_middleware::{ClientBuilder, Extension};
+/// use reqwest_tracing::{
+///     TracingMiddleware, DisableOtelPropagation
+/// };
+/// # async fn example() -> Result<()> {
+/// let reqwest_client = reqwest::Client::builder().build().unwrap();
+/// let client = ClientBuilder::new(reqwest_client)
+///    // Inserts the extension before the request is started
+///    .with_init(Extension(DisableOtelPropagation))
+///    // Makes use of that extension to specify the otel name
+///    .with(TracingMiddleware::default())
+///    .build();
+///
+/// let resp = client.get("https://truelayer.com").send().await.unwrap();
+///
+/// // Or specify it on the individual request (will take priority)
+/// let resp = client.post("https://api.truelayer.com/payment")
+///     .with_extension(DisableOtelPropagation)
+///     .send()
+///     .await
+///     .unwrap();
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Clone)]
+pub struct DisableOtelPropagation;
+
 /// Removes the username and/or password parts of the url, if present.
 fn remove_credentials(url: &Url) -> Cow<'_, str> {
     if !url.username().is_empty() || url.password().is_some() {


### PR DESCRIPTION
Some HTTP clients want to be traced, but do not want to propagate the opentelemetry contexts. Adding the `DisableOtelPropagation` extension will disable the propagation functionality

A future breaking change: split tracing and telemetry propagation into 2 middlewares.

Also drive-by fixed #85 