### PR TITLE
add opentelementry 0.20 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           - opentelemetry_0_17
           - opentelemetry_0_18
           - opentelemetry_0_19
+          - opentelemetry_0_20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -46,6 +47,7 @@ jobs:
           - opentelemetry_0_17
           - opentelemetry_0_18
           - opentelemetry_0_19
+          - opentelemetry_0_20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -93,6 +95,7 @@ jobs:
           - opentelemetry_0_17
           - opentelemetry_0_18
           - opentelemetry_0_19
+          - opentelemetry_0_20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -122,6 +125,7 @@ jobs:
           - opentelemetry_0_17
           - opentelemetry_0_18
           - opentelemetry_0_19
+          - opentelemetry_0_20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -17,6 +17,7 @@ opentelemetry_0_16 = ["opentelemetry_0_16_pkg", "tracing-opentelemetry_0_16_pkg"
 opentelemetry_0_17 = ["opentelemetry_0_17_pkg", "tracing-opentelemetry_0_17_pkg"]
 opentelemetry_0_18 = ["opentelemetry_0_18_pkg", "tracing-opentelemetry_0_18_pkg"]
 opentelemetry_0_19 = ["opentelemetry_0_19_pkg", "tracing-opentelemetry_0_19_pkg"]
+opentelemetry_0_20 = ["opentelemetry_0_20_pkg", "tracing-opentelemetry_0_20_pkg"]
 
 
 [dependencies]
@@ -36,6 +37,7 @@ opentelemetry_0_16_pkg = { package = "opentelemetry", version = "0.16.0", option
 opentelemetry_0_17_pkg = { package = "opentelemetry", version = "0.17.0", optional = true }
 opentelemetry_0_18_pkg = { package = "opentelemetry", version = "0.18.0", optional = true }
 opentelemetry_0_19_pkg = { package = "opentelemetry", version = "0.19.0", optional = true }
+opentelemetry_0_20_pkg = { package = "opentelemetry", version = "0.20.0", optional = true }
 tracing-opentelemetry_0_12_pkg = { package = "tracing-opentelemetry",version = "0.12.0", optional = true }
 tracing-opentelemetry_0_13_pkg = { package = "tracing-opentelemetry", version = "0.13.0", optional = true }
 tracing-opentelemetry_0_14_pkg = { package = "tracing-opentelemetry",version = "0.14.0", optional = true }
@@ -43,6 +45,7 @@ tracing-opentelemetry_0_16_pkg = { package = "tracing-opentelemetry",version = "
 tracing-opentelemetry_0_17_pkg = { package = "tracing-opentelemetry",version = "0.17.0", optional = true }
 tracing-opentelemetry_0_18_pkg = { package = "tracing-opentelemetry",version = "0.18.0", optional = true }
 tracing-opentelemetry_0_19_pkg = { package = "tracing-opentelemetry",version = "0.19.0", optional = true }
+tracing-opentelemetry_0_20_pkg = { package = "tracing-opentelemetry",version = "0.20.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.0", features = ["js"] }
@@ -52,3 +55,5 @@ tokio = { version = "1.0.0", features = ["macros"] }
 tracing_subscriber_0_2 = { package = "tracing-subscriber", version = "0.2.0" }
 tracing_subscriber_0_3 = { package = "tracing-subscriber", version = "0.3.0" }
 wiremock = "0.5.0"
+
+opentelemetry-stdout = { version = "0.1.0", features = ["trace"] }

--- a/reqwest-tracing/src/lib.rs
+++ b/reqwest-tracing/src/lib.rs
@@ -91,6 +91,7 @@ mod middleware;
     feature = "opentelemetry_0_17",
     feature = "opentelemetry_0_18",
     feature = "opentelemetry_0_19",
+    feature = "opentelemetry_0_20",
 ))]
 mod otel;
 mod reqwest_otel_span_builder;

--- a/reqwest-tracing/src/middleware.rs
+++ b/reqwest-tracing/src/middleware.rs
@@ -53,6 +53,7 @@ where
                 feature = "opentelemetry_0_17",
                 feature = "opentelemetry_0_18",
                 feature = "opentelemetry_0_19",
+                feature = "opentelemetry_0_20",
             ))]
             let req = if !extensions.contains::<crate::DisableOtelPropagation>() {
                 // Adds tracing headers to the given request to propagate the OpenTelemetry context to downstream revivers of the request.


### PR DESCRIPTION
Some features were removed in opentelemetry 0.20 and moved into separate crates, it only seems to effect tests though. No harm done.

The opentelemtry github repo suggests that they are releasing opentelemetry 1.0.0 shortly, I'd recommend removing all features and releasing a breaking change with the old versions removed once that happens