### PR TITLE
readme: add link to reqwest-chain crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,4 @@ The following third-party middleware use `request-middleware`:
 - [`reqwest-cache`](https://gitlab.com/famedly/company/backend/libraries/reqwest-cache) - HTTP caching
 - [`aliri_reqwest`](https://github.com/neoeinstein/aliri/tree/main/aliri_reqwest) - Background token management and renewal
 - [`http-signature-normalization-reqwest`](https://crates.io/crates/http-signature-normalization-reqwest) (not free software) - HTTP Signatures
+- [`reqwest-chain`](https://github.com/tommilligan/reqwest-chain) - Apply custom criteria to any reqwest response, deciding when and how to retry.


### PR DESCRIPTION
Hi, thanks for creating and maintaining this crate. I recently used it to implement some middleware for auto-refreshing OAuth access tokens - as part of the process I factored out [`reqwest-chain`](https://github.com/tommilligan/reqwest-chain) as a reusable abstraction.

I think this fills a niche where simply retrying with the same request (`reqwest-retry`) is not sufficient - you want to update the request based on the response you got. It's a pretty thin layer on top of `request-middleware`, but I found the abstraction helpful in constraining my eventual solution.

There is a minimal example in the [README](https://github.com/tommilligan/reqwest-chain#getting-started) if your're interested, otherwise I'd appreciate a link in your README for visibility!