### PR TITLE
[EWT-319] Upgrade retry-policies

### DIFF
--- a/reqwest-retry/CHANGELOG.md
+++ b/reqwest-retry/CHANGELOG.md
@@ -4,8 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2023-09-07
+### Changed
+- `retry-policies` upgraded to 0.2.0
+
 ## [0.2.3] - 2023-08-30
-### Added 
+### Added
 - `RetryableStrategy` which allows for custom retry decisions based on the response that a request got
 
 ## [0.2.1] - 2022-12-01

--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-retry"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Retry middleware for reqwest."
@@ -18,7 +18,7 @@ chrono = { version = "0.4.19", features = ["clock"], default-features = false }
 futures = "0.3.0"
 http = "0.2.0"
 reqwest = { version = "0.11.0", default-features = false }
-retry-policies = "0.1.0"
+retry-policies = "0.2.0"
 task-local-extensions = "0.1.4"
 tracing = "0.1.26"
 

--- a/reqwest-retry/tests/all/retry.rs
+++ b/reqwest-retry/tests/all/retry.rs
@@ -53,12 +53,12 @@ macro_rules! assert_retry_succeeds_inner {
             let reqwest_client = Client::builder().build().unwrap();
             let client = ClientBuilder::new(reqwest_client)
                 .with(RetryTransientMiddleware::new_with_policy(
-                    ExponentialBackoff {
-                        max_n_retries: retry_amount,
-                        max_retry_interval: std::time::Duration::from_millis(30),
-                        min_retry_interval: std::time::Duration::from_millis(100),
-                        backoff_exponent: 2,
-                    },
+                    ExponentialBackoff::builder()
+                        .retry_bounds(
+                            std::time::Duration::from_millis(30),
+                            std::time::Duration::from_millis(100),
+                        )
+                        .build_with_max_retries(retry_amount),
                 ))
                 .build();
 
@@ -189,12 +189,12 @@ async fn assert_retry_on_request_timeout() {
     let reqwest_client = Client::builder().build().unwrap();
     let client = ClientBuilder::new(reqwest_client)
         .with(RetryTransientMiddleware::new_with_policy(
-            ExponentialBackoff {
-                max_n_retries: 3,
-                max_retry_interval: std::time::Duration::from_millis(100),
-                min_retry_interval: std::time::Duration::from_millis(30),
-                backoff_exponent: 2,
-            },
+            ExponentialBackoff::builder()
+                .retry_bounds(
+                    std::time::Duration::from_millis(30),
+                    std::time::Duration::from_millis(100),
+                )
+                .build_with_max_retries(3),
         ))
         .build();
 
@@ -244,12 +244,12 @@ async fn assert_retry_on_incomplete_message() {
     let reqwest_client = Client::builder().build().unwrap();
     let client = ClientBuilder::new(reqwest_client)
         .with(RetryTransientMiddleware::new_with_policy(
-            ExponentialBackoff {
-                max_n_retries: 3,
-                max_retry_interval: std::time::Duration::from_millis(100),
-                min_retry_interval: std::time::Duration::from_millis(30),
-                backoff_exponent: 2,
-            },
+            ExponentialBackoff::builder()
+                .retry_bounds(
+                    std::time::Duration::from_millis(30),
+                    std::time::Duration::from_millis(100),
+                )
+                .build_with_max_retries(3),
         ))
         .build();
 
@@ -295,12 +295,12 @@ async fn assert_retry_on_hyper_canceled() {
     let reqwest_client = Client::builder().build().unwrap();
     let client = ClientBuilder::new(reqwest_client)
         .with(RetryTransientMiddleware::new_with_policy(
-            ExponentialBackoff {
-                max_n_retries: 3,
-                max_retry_interval: std::time::Duration::from_millis(100),
-                min_retry_interval: std::time::Duration::from_millis(30),
-                backoff_exponent: 2,
-            },
+            ExponentialBackoff::builder()
+                .retry_bounds(
+                    std::time::Duration::from_millis(30),
+                    std::time::Duration::from_millis(100),
+                )
+                .build_with_max_retries(3),
         ))
         .build();
 
@@ -343,12 +343,12 @@ async fn assert_retry_on_connection_reset_by_peer() {
     let reqwest_client = Client::builder().build().unwrap();
     let client = ClientBuilder::new(reqwest_client)
         .with(RetryTransientMiddleware::new_with_policy(
-            ExponentialBackoff {
-                max_n_retries: 3,
-                max_retry_interval: std::time::Duration::from_millis(100),
-                min_retry_interval: std::time::Duration::from_millis(30),
-                backoff_exponent: 2,
-            },
+            ExponentialBackoff::builder()
+                .retry_bounds(
+                    std::time::Duration::from_millis(30),
+                    std::time::Duration::from_millis(100),
+                )
+                .build_with_max_retries(3),
         ))
         .build();
 


### PR DESCRIPTION
Backwards-incompatible because this forces clients to also upgrade `retry-policies`.

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/reqwest-middleware/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CHANGELOG.md
-->
