### PR TITLE
Disable wasm tests and add warning to README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,35 +34,6 @@ jobs:
           command: test
           args: --workspace --all-targets --features ${{ matrix.otel_version }}
 
-  wasm:
-    name: Compiles for the browser
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        otel_version:
-          - opentelemetry_0_13
-          - opentelemetry_0_14
-          - opentelemetry_0_15
-          - opentelemetry_0_16
-          - opentelemetry_0_17
-          - opentelemetry_0_18
-          - opentelemetry_0_19
-          - opentelemetry_0_20
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          target: wasm32-unknown-unknown
-          toolchain: stable
-          profile: minimal
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --workspace --features ${{ matrix.otel_version }} --target wasm32-unknown-unknown
-
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ implementations. This repository also contains a couple of useful concrete middl
 
 Note about browser support: automated tests targetting wasm are disabled. The crate may work with
 wasm but wasm support is unmaintained. PRs improving wasm are still welcome but you'd need to
-reintroduce the tests and get them passing before we'd merge it.
+reintroduce the tests and get them passing before we'd merge it (see
+https://github.com/TrueLayer/reqwest-middleware/pull/105).
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ implementations. This repository also contains a couple of useful concrete middl
 * [`reqwest-tracing`](https://crates.io/crates/reqwest-tracing):
   [`tracing`](https://crates.io/crates/tracing) integration, optional opentelemetry support.
 
+Note about browser support: automated tests targetting wasm are disabled. The crate may work with
+wasm but wasm support is unmaintained. PRs improving wasm are still welcome but you'd need to
+reintroduce the tests and get them passing before we'd merge it.
+
 ## Overview
 
 The `reqwest-middleware` client exposes the same interface as a plain `reqwest` client, but


### PR DESCRIPTION
Wasm tests have been unmaintained and broken for a while. We don't use it so we have no motivation to update them, I removed the tests and added a warning that the crates may or may not work with wasm.