### PR TITLE
add fetch_mode_no_cors_method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [0.2.4] - 2023-09-21
+
+### Added
+- Added `fetch_mode_no_cors` method to `reqwest_middleware::RequestBuilder`
+
 ## [0.2.3] - 2023-08-07
 
 ### Added

--- a/reqwest-middleware/Cargo.toml
+++ b/reqwest-middleware/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-middleware"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Wrapper around reqwest to allow for client middleware chains."

--- a/reqwest-middleware/src/client.rs
+++ b/reqwest-middleware/src/client.rs
@@ -282,6 +282,13 @@ impl RequestBuilder {
         }
     }
 
+    pub fn fetch_mode_no_cors(self) -> Self {
+        RequestBuilder {
+            inner: self.inner.fetch_mode_no_cors(),
+            ..self
+        }
+    }
+
     pub fn build(self) -> reqwest::Result<Request> {
         self.inner.build()
     }


### PR DESCRIPTION
<!-- Please explain the changes you made -->
This adds the `fetch_mode_no_cors` method which is available in `reqwest::RequestBuilder` but currently not in `reqwest_middleware::RequestBuilder`.

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/reqwest-middleware/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CHANGELOG.md
-->
