### PR TITLE
Document using `tokio::time::sleep`

### DIFF
--- a/reqwest-retry/src/middleware.rs
+++ b/reqwest-retry/src/middleware.rs
@@ -12,7 +12,7 @@ use task_local_extensions::Extensions;
 /// and can be safely executed again.
 ///
 /// Currently, it allows setting a [RetryPolicy] algorithm for calculating the __wait_time__
-/// between each request retry. Sleeping is non-`wasm32` archs is performed using 
+/// between each request retry. Sleeping on non-`wasm32` archs is performed using 
 /// [`tokio::time::sleep`], therefore it will respect pauses/auto-advance if run under a
 /// runtime that supports them.
 ///

--- a/reqwest-retry/src/middleware.rs
+++ b/reqwest-retry/src/middleware.rs
@@ -12,7 +12,9 @@ use task_local_extensions::Extensions;
 /// and can be safely executed again.
 ///
 /// Currently, it allows setting a [RetryPolicy] algorithm for calculating the __wait_time__
-/// between each request retry.
+/// between each request retry. Sleeping is non-`wasm32` archs is performed using 
+/// [`tokio::time::sleep`], therefore it will respect pauses/auto-advance if run under a
+/// runtime that supports them.
 ///
 ///```rust
 ///     use reqwest_middleware::ClientBuilder;


### PR DESCRIPTION
<!-- Please explain the changes you made -->

Document that sleeps happen with `tokio::time::sleep` if anyone wants to run it in time-stepped environment (some unit test or something).

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/reqwest-middleware/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CHANGELOG.md
-->

N/A