### PR TITLE
Update reqwest version to 0.11.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Changed minimum version of `reqwest` to `0.11.10`. url_mut, with_url, without_url functions are added after `0.11.10`.
+
 ### [0.2.4] - 2023-09-21
 
 ### Added

--- a/reqwest-middleware/Cargo.toml
+++ b/reqwest-middleware/Cargo.toml
@@ -14,13 +14,12 @@ readme = "../README.md"
 anyhow = "1.0.0"
 async-trait = "0.1.51"
 http = "0.2.0"
-reqwest = { version = "0.11.4", default-features = false, features = ["json", "multipart"] }
+reqwest = { version = "0.11.10", default-features = false, features = ["json", "multipart"] }
 serde = "1.0.106"
 task-local-extensions = "0.1.4"
 thiserror = "1.0.21"
 
 [dev-dependencies]
-reqwest = "0.11.10"
 reqwest-retry = { path = "../reqwest-retry" }
 reqwest-tracing = { path = "../reqwest-tracing" }
 tokio = { version = "1.0.0", features = ["macros", "rt-multi-thread"] }

--- a/reqwest-middleware/Cargo.toml
+++ b/reqwest-middleware/Cargo.toml
@@ -20,7 +20,7 @@ task-local-extensions = "0.1.4"
 thiserror = "1.0.21"
 
 [dev-dependencies]
-reqwest = "0.11.4"
+reqwest = "0.11.10"
 reqwest-retry = { path = "../reqwest-retry" }
 reqwest-tracing = { path = "../reqwest-tracing" }
 tokio = { version = "1.0.0", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
<!-- Please explain the changes you made -->
The minimum version of reqwest `0.11.4` is no longer true after 0.2.3 release
- Added all `reqwest::Error` methods for `reqwest_middleware::Error`

methods url_mut, with_url, without_url were added after `0.11.10`

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/reqwest-middleware/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CHANGELOG.md
-->
