### PR TITLE
Support opentelemetry 0.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           - opentelemetry_0_19
           - opentelemetry_0_20
           - opentelemetry_0_21
+          - opentelemetry_0_22
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -69,6 +70,7 @@ jobs:
           - opentelemetry_0_19
           - opentelemetry_0_20
           - opentelemetry_0_21
+          - opentelemetry_0_22
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -100,6 +102,7 @@ jobs:
           - opentelemetry_0_19
           - opentelemetry_0_20
           - opentelemetry_0_21
+          - opentelemetry_0_22
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -19,6 +19,7 @@ opentelemetry_0_18 = ["opentelemetry_0_18_pkg", "tracing-opentelemetry_0_18_pkg"
 opentelemetry_0_19 = ["opentelemetry_0_19_pkg", "tracing-opentelemetry_0_19_pkg"]
 opentelemetry_0_20 = ["opentelemetry_0_20_pkg", "tracing-opentelemetry_0_20_pkg"]
 opentelemetry_0_21 = ["opentelemetry_0_21_pkg", "tracing-opentelemetry_0_22_pkg"]
+opentelemetry_0_22 = ["opentelemetry_0_22_pkg", "tracing-opentelemetry_0_23_pkg"]
 
 
 [dependencies]
@@ -40,6 +41,7 @@ opentelemetry_0_18_pkg = { package = "opentelemetry", version = "0.18.0", option
 opentelemetry_0_19_pkg = { package = "opentelemetry", version = "0.19.0", optional = true }
 opentelemetry_0_20_pkg = { package = "opentelemetry", version = "0.20.0", optional = true }
 opentelemetry_0_21_pkg = { package = "opentelemetry", version = "0.21.0", optional = true }
+opentelemetry_0_22_pkg = { package = "opentelemetry", version = "0.22.0", optional = true }
 tracing-opentelemetry_0_12_pkg = { package = "tracing-opentelemetry", version = "0.12.0", optional = true }
 tracing-opentelemetry_0_13_pkg = { package = "tracing-opentelemetry", version = "0.13.0", optional = true }
 tracing-opentelemetry_0_14_pkg = { package = "tracing-opentelemetry", version = "0.14.0", optional = true }
@@ -49,6 +51,7 @@ tracing-opentelemetry_0_18_pkg = { package = "tracing-opentelemetry", version = 
 tracing-opentelemetry_0_19_pkg = { package = "tracing-opentelemetry", version = "0.19.0", optional = true }
 tracing-opentelemetry_0_20_pkg = { package = "tracing-opentelemetry", version = "0.20.0", optional = true }
 tracing-opentelemetry_0_22_pkg = { package = "tracing-opentelemetry", version = "0.22.0", optional = true }
+tracing-opentelemetry_0_23_pkg = { package = "tracing-opentelemetry", version = "0.23.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.0", features = ["js"] }

--- a/reqwest-tracing/README.md
+++ b/reqwest-tracing/README.md
@@ -92,7 +92,7 @@ an opentelemetry version feature:
 reqwest-tracing = { version = "0.3.1", features = ["opentelemetry_0_18"] }
 ```
 
-Available opentelemetry features are `opentelemetry_0_21`, `opentelemetry_0_20`,
+Available opentelemetry features are `opentelemetry_0_22`, `opentelemetry_0_21`, `opentelemetry_0_20`,
 `opentelemetry_0_19`, `opentelemetry_0_18`, `opentelemetry_0_17`, `opentelemetry_0_16`,
 `opentelemetry_0_15`, `opentelemetry_0_14` and `opentelemetry_0_13`.
 

--- a/reqwest-tracing/src/lib.rs
+++ b/reqwest-tracing/src/lib.rs
@@ -93,6 +93,7 @@ mod middleware;
     feature = "opentelemetry_0_19",
     feature = "opentelemetry_0_20",
     feature = "opentelemetry_0_21",
+    feature = "opentelemetry_0_22",
 ))]
 mod otel;
 mod reqwest_otel_span_builder;

--- a/reqwest-tracing/src/middleware.rs
+++ b/reqwest-tracing/src/middleware.rs
@@ -55,6 +55,7 @@ where
                 feature = "opentelemetry_0_19",
                 feature = "opentelemetry_0_20",
                 feature = "opentelemetry_0_21",
+                feature = "opentelemetry_0_22",
             ))]
             let req = if !extensions.contains::<crate::DisableOtelPropagation>() {
                 // Adds tracing headers to the given request to propagate the OpenTelemetry context to downstream revivers of the request.


### PR DESCRIPTION
Opentelemetry 0.22 is released.

Once https://github.com/tokio-rs/tracing-opentelemetry/pull/100 
is into a release (presumably 0.23), then this PR should pass CI and be mergable.
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/reqwest-middleware/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CHANGELOG.md
-->
