### PR TITLE
update packages dependant on http v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Updated version ot 'http' to '1.1.0'
+- Updated version ot 'hyper' to '1.2.0'
+- Updated version ot 'wiremock' to '0.6.0'
+- Updated version ot 'wiremock' to '0.12.0'
 
 ### [0.2.5] - 2024-03-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Updated version ot 'http' to '1.1.0'
-- Updated version ot 'hyper' to '1.2.0'
-- Updated version ot 'wiremock' to '0.6.0'
-- Updated version ot 'wiremock' to '0.12.0'
+- Updated version of 'http' to '1.1.0'
+- Updated version of 'hyper' to '1.2.0'
+- Updated version of 'wiremock' to '0.6.0'
+- Updated version of 'reqwest' to '0.12.0'
 
 ### [0.2.5] - 2024-03-15
 

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ The `reqwest-middleware` client exposes the same interface as a plain `reqwest` 
 # Cargo.toml
 # ...
 [dependencies]
-reqwest = "0.11"
-reqwest-middleware = "0.1.6"
-reqwest-retry = "0.1.5"
-reqwest-tracing = "0.2.3"
+reqwest = "0.12"
+reqwest-middleware = "0.2.5"
+reqwest-retry = "0.4.0"
+reqwest-tracing = "0.4.8"
 tokio = { version = "1.12.0", features = ["macros", "rt-multi-thread"] }
 ```
 

--- a/reqwest-middleware/Cargo.toml
+++ b/reqwest-middleware/Cargo.toml
@@ -20,6 +20,7 @@ task-local-extensions = "0.1.4"
 thiserror = "1.0.21"
 
 [dev-dependencies]
+reqwest = { version = "0.12.0", default-features = false, features = ["json", "multipart", "native-tls"] }
 reqwest-retry = { path = "../reqwest-retry" }
 reqwest-tracing = { path = "../reqwest-tracing" }
 tokio = { version = "1.0.0", features = ["macros", "rt-multi-thread"] }

--- a/reqwest-middleware/Cargo.toml
+++ b/reqwest-middleware/Cargo.toml
@@ -13,8 +13,8 @@ readme = "../README.md"
 [dependencies]
 anyhow = "1.0.0"
 async-trait = "0.1.51"
-http = "0.2.0"
-reqwest = { version = "0.11.10", default-features = false, features = ["json", "multipart"] }
+http = "1.1.0"
+reqwest = { version = "0.12.0", default-features = false, features = ["json", "multipart"] }
 serde = "1.0.106"
 task-local-extensions = "0.1.4"
 thiserror = "1.0.21"
@@ -23,4 +23,4 @@ thiserror = "1.0.21"
 reqwest-retry = { path = "../reqwest-retry" }
 reqwest-tracing = { path = "../reqwest-tracing" }
 tokio = { version = "1.0.0", features = ["macros", "rt-multi-thread"] }
-wiremock = "0.5.0"
+wiremock = "0.6.0"

--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -16,14 +16,14 @@ anyhow = "1.0.0"
 async-trait = "0.1.51"
 chrono = { version = "0.4.19", features = ["clock"], default-features = false }
 futures = "0.3.0"
-http = "0.2.0"
-reqwest = { version = "0.11.0", default-features = false }
+http = "1.1.0"
+reqwest = { version = "0.12.0", default-features = false }
 retry-policies = "0.3.0"
 task-local-extensions = "0.1.4"
 tracing = "0.1.26"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-hyper = "0.14.0"
+hyper = "1.2.0"
 tokio = { version = "1.6.0", features = ["time"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -34,5 +34,5 @@ getrandom = { version = "0.2.0", features = ["js"] }
 [dev-dependencies]
 paste = "1.0.0"
 tokio = { version = "1.0.0", features = ["full"] }
-wiremock = "0.5.0"
+wiremock = "0.6.0"
 futures = "0.3.0"

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -28,7 +28,7 @@ reqwest-middleware = { version = "0.2.0", path = "../reqwest-middleware" }
 anyhow = "1.0.70"
 async-trait = "0.1.51"
 matchit = "0.7.0"
-reqwest = { version = "0.11.0", default-features = false }
+reqwest = { version = "0.12.0", default-features = false }
 task-local-extensions = "0.1.4"
 tracing = "0.1.26"
 
@@ -60,7 +60,7 @@ getrandom = { version = "0.2.0", features = ["js"] }
 tokio = { version = "1.0.0", features = ["macros"] }
 tracing_subscriber_0_2 = { package = "tracing-subscriber", version = "0.2.0" }
 tracing_subscriber_0_3 = { package = "tracing-subscriber", version = "0.3.0" }
-wiremock = "0.5.0"
+wiremock = "0.6.0"
 
 opentelemetry_sdk_0_21 = { package = "opentelemetry_sdk", version = "0.21.0", features = ["trace"] }
 opentelemetry_sdk_0_22 = { package = "opentelemetry_sdk", version = "0.22.0", features = ["trace"] }

--- a/reqwest-tracing/README.md
+++ b/reqwest-tracing/README.md
@@ -17,10 +17,10 @@ Attach `TracingMiddleware` to your client to automatically trace HTTP requests:
 # ...
 [dependencies]
 opentelemetry = "0.18"
-reqwest = "0.11"
-reqwest-middleware = "0.1.1"
-reqwest-retry = "0.1.1"
-reqwest-tracing = { version = "0.3.1", features = ["opentelemetry_0_18"] }
+reqwest = "0.12"
+reqwest-middleware = "0.2.5"
+reqwest-retry = "0.4.0"
+reqwest-tracing = { version = "0.4.8", features = ["opentelemetry_0_18"] }
 tokio = { version = "1.12.0", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-opentelemetry = "0.18"
@@ -89,7 +89,7 @@ an opentelemetry version feature:
 ```toml
 [dependencies]
 # ...
-reqwest-tracing = { version = "0.3.1", features = ["opentelemetry_0_18"] }
+reqwest-tracing = { version = "0.4.8", features = ["opentelemetry_0_18"] }
 ```
 
 Available opentelemetry features are `opentelemetry_0_22`, `opentelemetry_0_21`, `opentelemetry_0_20`,


### PR DESCRIPTION
Updated reqwest, hyper and wire mock to work with http v1
