### PR TITLE
Support reqwest 0.12.1 (#132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### [0.2.5] - 2024-03-25
+- Support for `reqwest` `0.12.1`
+- Support for `matchit` `0.8.0` - This means router matches like `/a/:some_var`  need to be changed to `/a/{some_var}`
+- General cargo upgrade
+
 ### [0.2.5] - 2024-03-15
 
 ### Changed

--- a/reqwest-middleware/Cargo.toml
+++ b/reqwest-middleware/Cargo.toml
@@ -11,17 +11,17 @@ categories = ["web-programming::http-client"]
 readme = "../README.md"
 
 [dependencies]
-anyhow = "1.0.0"
-async-trait = "0.1.51"
-http = "0.2.0"
-reqwest = { version = "0.11.10", default-features = false, features = ["json", "multipart"] }
-serde = "1.0.106"
+anyhow = "1.0.81"
+async-trait = "0.1.79"
+http = "0.2.12"
+reqwest = { version = "0.11.27", default-features = false, features = ["json", "multipart"] }
+serde = "1.0.197"
 task-local-extensions = "0.1.4"
-thiserror = "1.0.21"
+thiserror = "1.0.58"
 
 [dev-dependencies]
-reqwest = { version = "0.11.10", features = ["rustls"] }
+reqwest = { version = "0.11.27", features = ["rustls"] }
 reqwest-retry = { path = "../reqwest-retry" }
 reqwest-tracing = { path = "../reqwest-tracing" }
-tokio = { version = "1.0.0", features = ["macros", "rt-multi-thread"] }
-wiremock = "0.5.0"
+tokio = { version = "1.36.0", features = ["macros", "rt-multi-thread"] }
+wiremock = "0.5.22"

--- a/reqwest-middleware/Cargo.toml
+++ b/reqwest-middleware/Cargo.toml
@@ -20,6 +20,7 @@ task-local-extensions = "0.1.4"
 thiserror = "1.0.21"
 
 [dev-dependencies]
+reqwest = { version = "0.11.10", features = ["rustls"] }
 reqwest-retry = { path = "../reqwest-retry" }
 reqwest-tracing = { path = "../reqwest-tracing" }
 tokio = { version = "1.0.0", features = ["macros", "rt-multi-thread"] }

--- a/reqwest-middleware/Cargo.toml
+++ b/reqwest-middleware/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-middleware"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Wrapper around reqwest to allow for client middleware chains."
@@ -13,15 +13,15 @@ readme = "../README.md"
 [dependencies]
 anyhow = "1.0.81"
 async-trait = "0.1.79"
-http = "0.2.12"
-reqwest = { version = "0.11.27", default-features = false, features = ["json", "multipart"] }
+http = "1.1.0"
+reqwest = { version = "0.12.1", default-features = false, features = ["json", "multipart"] }
 serde = "1.0.197"
 task-local-extensions = "0.1.4"
 thiserror = "1.0.58"
 
 [dev-dependencies]
-reqwest = { version = "0.11.27", features = ["rustls"] }
+reqwest = { version = "0.12.1", features = ["rustls-tls"] }
 reqwest-retry = { path = "../reqwest-retry" }
 reqwest-tracing = { path = "../reqwest-tracing" }
 tokio = { version = "1.36.0", features = ["macros", "rt-multi-thread"] }
-wiremock = "0.5.22"
+wiremock = "0.6.0"

--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -12,27 +12,27 @@ categories = ["web-programming::http-client"]
 [dependencies]
 reqwest-middleware = { version = "0.2.0", path = "../reqwest-middleware" }
 
-anyhow = "1.0.0"
-async-trait = "0.1.51"
-chrono = { version = "0.4.19", features = ["clock"], default-features = false }
-futures = "0.3.0"
-http = "0.2.0"
-reqwest = { version = "0.11.0", default-features = false }
+anyhow = "1.0.81"
+async-trait = "0.1.79"
+chrono = { version = "0.4.35", features = ["clock"], default-features = false }
+futures = "0.3.30"
+http = "0.2.12"
+reqwest = { version = "0.11.27", default-features = false }
 retry-policies = "0.3.0"
 task-local-extensions = "0.1.4"
-tracing = "0.1.26"
+tracing = "0.1.40"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-hyper = "0.14.0"
-tokio = { version = "1.6.0", features = ["time"] }
+hyper = "0.14.28"
+tokio = { version = "1.36.0", features = ["time"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 parking_lot = { version = "0.11.2", features = ["wasm-bindgen"] } # work around https://github.com/tomaka/wasm-timer/issues/14
 wasm-timer = "0.2.5"
-getrandom = { version = "0.2.0", features = ["js"] }
+getrandom = { version = "0.2.12", features = ["js"] }
 
 [dev-dependencies]
-paste = "1.0.0"
-tokio = { version = "1.0.0", features = ["full"] }
-wiremock = "0.5.0"
-futures = "0.3.0"
+paste = "1.0.14"
+tokio = { version = "1.36.0", features = ["full"] }
+wiremock = "0.5.22"
+futures = "0.3.30"

--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-retry"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Retry middleware for reqwest."
@@ -16,23 +16,23 @@ anyhow = "1.0.81"
 async-trait = "0.1.79"
 chrono = { version = "0.4.35", features = ["clock"], default-features = false }
 futures = "0.3.30"
-http = "0.2.12"
-reqwest = { version = "0.11.27", default-features = false }
+http = "1.1.0"
+reqwest = { version = "0.12.1", default-features = false }
 retry-policies = "0.3.0"
 task-local-extensions = "0.1.4"
 tracing = "0.1.40"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-hyper = "0.14.28"
+hyper = "1.2.0"
 tokio = { version = "1.36.0", features = ["time"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-parking_lot = { version = "0.11.2", features = ["wasm-bindgen"] } # work around https://github.com/tomaka/wasm-timer/issues/14
+parking_lot = { version = "0.12.1" }
 wasm-timer = "0.2.5"
 getrandom = { version = "0.2.12", features = ["js"] }
 
 [dev-dependencies]
 paste = "1.0.14"
 tokio = { version = "1.36.0", features = ["full"] }
-wiremock = "0.5.22"
+wiremock = "0.6.0"
 futures = "0.3.30"

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-tracing"
-version = "0.4.8"
+version = "0.4.9"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Opentracing middleware for reqwest."
@@ -27,8 +27,8 @@ reqwest-middleware = { version = "0.2.0", path = "../reqwest-middleware" }
 
 anyhow = "1.0.81"
 async-trait = "0.1.79"
-matchit = "0.7.3"
-reqwest = { version = "0.11.27", default-features = false }
+matchit = "0.8.0"
+reqwest = { version = "0.12.1", default-features = false }
 task-local-extensions = "0.1.4"
 tracing = "0.1.40"
 
@@ -60,7 +60,7 @@ getrandom = { version = "0.2.12", features = ["js"] }
 tokio = { version = "1.36.0", features = ["macros"] }
 tracing_subscriber_0_2 = { package = "tracing-subscriber", version = "0.2.25" }
 tracing_subscriber_0_3 = { package = "tracing-subscriber", version = "0.3.18" }
-wiremock = "0.5.22"
+wiremock = "0.6.0"
 
 opentelemetry_sdk_0_21 = { package = "opentelemetry_sdk", version = "0.21.2", features = ["trace"] }
 opentelemetry_sdk_0_22 = { package = "opentelemetry_sdk", version = "0.22.1", features = ["trace"] }

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -25,12 +25,12 @@ opentelemetry_0_22 = ["opentelemetry_0_22_pkg", "tracing-opentelemetry_0_23_pkg"
 [dependencies]
 reqwest-middleware = { version = "0.2.0", path = "../reqwest-middleware" }
 
-anyhow = "1.0.70"
-async-trait = "0.1.51"
-matchit = "0.7.0"
-reqwest = { version = "0.11.0", default-features = false }
+anyhow = "1.0.81"
+async-trait = "0.1.79"
+matchit = "0.7.3"
+reqwest = { version = "0.11.27", default-features = false }
 task-local-extensions = "0.1.4"
-tracing = "0.1.26"
+tracing = "0.1.40"
 
 opentelemetry_0_13_pkg = { package = "opentelemetry", version = "0.13.0", optional = true }
 opentelemetry_0_14_pkg = { package = "opentelemetry", version = "0.14.0", optional = true }
@@ -46,7 +46,7 @@ tracing-opentelemetry_0_12_pkg = { package = "tracing-opentelemetry", version = 
 tracing-opentelemetry_0_13_pkg = { package = "tracing-opentelemetry", version = "0.13.0", optional = true }
 tracing-opentelemetry_0_14_pkg = { package = "tracing-opentelemetry", version = "0.14.0", optional = true }
 tracing-opentelemetry_0_16_pkg = { package = "tracing-opentelemetry", version = "0.16.0", optional = true }
-tracing-opentelemetry_0_17_pkg = { package = "tracing-opentelemetry", version = "0.17.0", optional = true }
+tracing-opentelemetry_0_17_pkg = { package = "tracing-opentelemetry", version = "0.17.4", optional = true }
 tracing-opentelemetry_0_18_pkg = { package = "tracing-opentelemetry", version = "0.18.0", optional = true }
 tracing-opentelemetry_0_19_pkg = { package = "tracing-opentelemetry", version = "0.19.0", optional = true }
 tracing-opentelemetry_0_20_pkg = { package = "tracing-opentelemetry", version = "0.20.0", optional = true }
@@ -54,16 +54,16 @@ tracing-opentelemetry_0_22_pkg = { package = "tracing-opentelemetry", version = 
 tracing-opentelemetry_0_23_pkg = { package = "tracing-opentelemetry", version = "0.23.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2.0", features = ["js"] }
+getrandom = { version = "0.2.12", features = ["js"] }
 
 [dev-dependencies]
-tokio = { version = "1.0.0", features = ["macros"] }
-tracing_subscriber_0_2 = { package = "tracing-subscriber", version = "0.2.0" }
-tracing_subscriber_0_3 = { package = "tracing-subscriber", version = "0.3.0" }
-wiremock = "0.5.0"
+tokio = { version = "1.36.0", features = ["macros"] }
+tracing_subscriber_0_2 = { package = "tracing-subscriber", version = "0.2.25" }
+tracing_subscriber_0_3 = { package = "tracing-subscriber", version = "0.3.18" }
+wiremock = "0.5.22"
 
-opentelemetry_sdk_0_21 = { package = "opentelemetry_sdk", version = "0.21.0", features = ["trace"] }
-opentelemetry_sdk_0_22 = { package = "opentelemetry_sdk", version = "0.22.0", features = ["trace"] }
+opentelemetry_sdk_0_21 = { package = "opentelemetry_sdk", version = "0.21.2", features = ["trace"] }
+opentelemetry_sdk_0_22 = { package = "opentelemetry_sdk", version = "0.22.1", features = ["trace"] }
 opentelemetry_stdout_0_1 = { package = "opentelemetry-stdout", version = "0.1.0", features = ["trace"] }
 opentelemetry_stdout_0_2 = { package = "opentelemetry-stdout", version = "0.2.0", features = ["trace"] }
 opentelemetry_stdout_0_3 = { package = "opentelemetry-stdout", version = "0.3.0", features = ["trace"] }

--- a/reqwest-tracing/src/reqwest_otel_span_builder.rs
+++ b/reqwest-tracing/src/reqwest_otel_span_builder.rs
@@ -267,9 +267,9 @@ impl OtelPathNames {
     ///
     /// ```
     /// # use reqwest_tracing::OtelPathNames;
-    /// let path_names = OtelPathNames::known_paths(["/payment/:paymentId"]).unwrap();
+    /// let path_names = OtelPathNames::known_paths(["/payment/{paymentId}"]).unwrap();
     /// let path = path_names.find("/payment/payment-id-123");
-    /// assert_eq!(path, Some("/payment/:paymentId"));
+    /// assert_eq!(path, Some("/payment/{paymentId}"));
     /// ```
     pub fn find(&self, path: &str) -> Option<&str> {
         self.0.at(path).map(|mtch| mtch.value.as_str()).ok()


### PR DESCRIPTION
To fix issue: <https://github.com/TrueLayer/reqwest-middleware/issues/132>

- Support for `reqwest` `0.12.1`
- Support for `matchit` `0.8.0` - This means router matches like `/a/:some_var`  need to be changed to `/a/{some_var}`
- General cargo upgrade
