### PR TITLE
reqwest 0.12 and other breaking changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,6 @@ jobs:
     strategy:
       matrix:
         otel_version:
-          - opentelemetry_0_13
-          - opentelemetry_0_14
-          - opentelemetry_0_15
           - opentelemetry_0_16
           - opentelemetry_0_17
           - opentelemetry_0_18
@@ -61,9 +58,6 @@ jobs:
     strategy:
       matrix:
         otel_version:
-          - opentelemetry_0_13
-          - opentelemetry_0_14
-          - opentelemetry_0_15
           - opentelemetry_0_16
           - opentelemetry_0_17
           - opentelemetry_0_18
@@ -102,9 +96,6 @@ jobs:
     strategy:
       matrix:
         otel_version:
-          - opentelemetry_0_13
-          - opentelemetry_0_14
-          - opentelemetry_0_15
           - opentelemetry_0_16
           - opentelemetry_0_17
           - opentelemetry_0_18

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,6 @@ jobs:
     strategy:
       matrix:
         otel_version:
-          - opentelemetry_0_16
-          - opentelemetry_0_17
-          - opentelemetry_0_18
-          - opentelemetry_0_19
           - opentelemetry_0_20
           - opentelemetry_0_21
           - opentelemetry_0_22
@@ -58,10 +54,6 @@ jobs:
     strategy:
       matrix:
         otel_version:
-          - opentelemetry_0_16
-          - opentelemetry_0_17
-          - opentelemetry_0_18
-          - opentelemetry_0_19
           - opentelemetry_0_20
           - opentelemetry_0_21
           - opentelemetry_0_22
@@ -96,10 +88,6 @@ jobs:
     strategy:
       matrix:
         otel_version:
-          - opentelemetry_0_16
-          - opentelemetry_0_17
-          - opentelemetry_0_18
-          - opentelemetry_0_19
           - opentelemetry_0_20
           - opentelemetry_0_21
           - opentelemetry_0_22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking changes
+- Updated `reqwest` to `0.12.0`.
+- Removed `task_local_extensions` in favour of `http::Extensions`.
+    - All extensions must be `Clone` now.
+- Replaced `with_arc` and `with_arc_init` methods with `with_box` and `with_box_init`.
+
+### Changed
+- `RequestBuilder::try_clone` now clones the extensions.
+
+### Added
+- implemented `Service` for `ClientWithMiddleware` to have more feature parity with `reqwest`.
+- Added more methods like `build_split` to have more feature parity with `reqwest.`
+- Added a lot more documentation
+
 ### [0.2.5] - 2024-03-15
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ The `reqwest-middleware` client exposes the same interface as a plain `reqwest` 
 # Cargo.toml
 # ...
 [dependencies]
-reqwest = "0.11"
-reqwest-middleware = "0.1.6"
-reqwest-retry = "0.1.5"
-reqwest-tracing = "0.2.3"
-tokio = { version = "1.12.0", features = ["macros", "rt-multi-thread"] }
+reqwest = { version = "0.12", features = ["rustls-tls"] }
+reqwest-middleware = "0.3"
+reqwest-retry = "0.5"
+reqwest-tracing = "0.5"
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 ```
 
 ```rust

--- a/reqwest-middleware/Cargo.toml
+++ b/reqwest-middleware/Cargo.toml
@@ -21,6 +21,7 @@ http = "1.0.0"
 reqwest = { version = "0.12.0", default-features = false }
 serde = "1.0.106"
 thiserror = "1.0.21"
+tower-service = "0.3.0"
 
 [dev-dependencies]
 reqwest-retry = { path = "../reqwest-retry" }

--- a/reqwest-middleware/Cargo.toml
+++ b/reqwest-middleware/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-middleware"
-version = "0.2.5"
+version = "0.3.0"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Wrapper around reqwest to allow for client middleware chains."
@@ -10,17 +10,20 @@ keywords = ["reqwest", "http", "middleware"]
 categories = ["web-programming::http-client"]
 readme = "../README.md"
 
+[features]
+multipart = ["reqwest/multipart"]
+json = ["reqwest/json"]
+
 [dependencies]
 anyhow = "1.0.0"
 async-trait = "0.1.51"
-http = "0.2.0"
-reqwest = { version = "0.11.10", default-features = false, features = ["json", "multipart"] }
+http = "1.0.0"
+reqwest = { version = "0.12.0", default-features = false }
 serde = "1.0.106"
-task-local-extensions = "0.1.4"
 thiserror = "1.0.21"
 
 [dev-dependencies]
 reqwest-retry = { path = "../reqwest-retry" }
 reqwest-tracing = { path = "../reqwest-tracing" }
 tokio = { version = "1.0.0", features = ["macros", "rt-multi-thread"] }
-wiremock = "0.5.0"
+wiremock = "0.6.0"

--- a/reqwest-middleware/src/client.rs
+++ b/reqwest-middleware/src/client.rs
@@ -18,8 +18,8 @@ use crate::RequestInitialiser;
 /// [`ClientWithMiddleware`]: crate::ClientWithMiddleware
 pub struct ClientBuilder {
     client: Client,
-    middleware_stack: Vec<Arc<dyn Middleware>>,
-    initialiser_stack: Vec<Arc<dyn RequestInitialiser>>,
+    middleware_stack: Vec<Box<dyn Middleware>>,
+    initialiser_stack: Vec<Box<dyn RequestInitialiser>>,
 }
 
 impl ClientBuilder {
@@ -33,40 +33,40 @@ impl ClientBuilder {
 
     /// Convenience method to attach middleware.
     ///
-    /// If you need to keep a reference to the middleware after attaching, use [`with_arc`].
+    /// If you need to keep a reference to the middleware after attaching, use [`with_box`].
     ///
-    /// [`with_arc`]: Self::with_arc
+    /// [`with_box`]: Self::with_box
     pub fn with<M>(self, middleware: M) -> Self
     where
         M: Middleware,
     {
-        self.with_arc(Arc::new(middleware))
+        self.with_box(Box::new(middleware))
     }
 
-    /// Add middleware to the chain. [`with`] is more ergonomic if you don't need the `Arc`.
+    /// Add middleware to the chain. [`with`] is more ergonomic if you don't need the `Box`.
     ///
     /// [`with`]: Self::with
-    pub fn with_arc(mut self, middleware: Arc<dyn Middleware>) -> Self {
+    pub fn with_box(mut self, middleware: Box<dyn Middleware>) -> Self {
         self.middleware_stack.push(middleware);
         self
     }
 
     /// Convenience method to attach a request initialiser.
     ///
-    /// If you need to keep a reference to the initialiser after attaching, use [`with_arc_init`].
+    /// If you need to keep a reference to the initialiser after attaching, use [`with_box_init`].
     ///
-    /// [`with_arc_init`]: Self::with_arc_init
+    /// [`with_box_init`]: Self::with_box_init
     pub fn with_init<I>(self, initialiser: I) -> Self
     where
         I: RequestInitialiser,
     {
-        self.with_arc_init(Arc::new(initialiser))
+        self.with_box_init(Box::new(initialiser))
     }
 
-    /// Add a request initialiser to the chain. [`with_init`] is more ergonomic if you don't need the `Arc`.
+    /// Add a request initialiser to the chain. [`with_init`] is more ergonomic if you don't need the `Box`.
     ///
     /// [`with_init`]: Self::with_init
-    pub fn with_arc_init(mut self, initialiser: Arc<dyn RequestInitialiser>) -> Self {
+    pub fn with_box_init(mut self, initialiser: Box<dyn RequestInitialiser>) -> Self {
         self.initialiser_stack.push(initialiser);
         self
     }
@@ -86,15 +86,15 @@ impl ClientBuilder {
 #[derive(Clone)]
 pub struct ClientWithMiddleware {
     inner: reqwest::Client,
-    middleware_stack: Arc<[Arc<dyn Middleware>]>,
-    initialiser_stack: Arc<[Arc<dyn RequestInitialiser>]>,
+    middleware_stack: Arc<[Box<dyn Middleware>]>,
+    initialiser_stack: Arc<[Box<dyn RequestInitialiser>]>,
 }
 
 impl ClientWithMiddleware {
     /// See [`ClientBuilder`] for a more ergonomic way to build `ClientWithMiddleware` instances.
     pub fn new<T>(client: Client, middleware_stack: T) -> Self
     where
-        T: Into<Arc<[Arc<dyn Middleware>]>>,
+        T: Into<Arc<[Box<dyn Middleware>]>>,
     {
         ClientWithMiddleware {
             inner: client,
@@ -314,8 +314,8 @@ mod service {
 #[must_use = "RequestBuilder does nothing until you 'send' it"]
 pub struct RequestBuilder {
     inner: reqwest::RequestBuilder,
-    middleware_stack: Arc<[Arc<dyn Middleware>]>,
-    initialiser_stack: Arc<[Arc<dyn RequestInitialiser>]>,
+    middleware_stack: Arc<[Box<dyn Middleware>]>,
+    initialiser_stack: Arc<[Box<dyn RequestInitialiser>]>,
     extensions: Extensions,
 }
 

--- a/reqwest-middleware/src/client.rs
+++ b/reqwest-middleware/src/client.rs
@@ -194,6 +194,18 @@ pub struct RequestBuilder {
 }
 
 impl RequestBuilder {
+    /// Assemble a builder starting from an existing `Client` and a `Request`.
+    pub fn from_parts(client: ClientWithMiddleware, request: Request) -> RequestBuilder {
+        let inner = reqwest::RequestBuilder::from_parts(client.inner, request);
+        RequestBuilder {
+            inner,
+            middleware_stack: client.middleware_stack,
+            initialiser_stack: client.initialiser_stack,
+            extensions: Extensions::new(),
+        }
+    }
+
+    /// Add a `Header` to this Request.
     pub fn header<K, V>(self, key: K, value: V) -> Self
     where
         HeaderName: TryFrom<K>,
@@ -207,6 +219,9 @@ impl RequestBuilder {
         }
     }
 
+    /// Add a set of Headers to the existing ones on this Request.
+    ///
+    /// The headers will be merged in to any already set.
     pub fn headers(self, headers: HeaderMap) -> Self {
         RequestBuilder {
             inner: self.inner.headers(headers),
@@ -222,6 +237,20 @@ impl RequestBuilder {
         }
     }
 
+    /// Enable HTTP basic authentication.
+    ///
+    /// ```rust
+    /// # use anyhow::Error;
+    ///
+    /// # async fn run() -> Result<(), Error> {
+    /// let client = reqwest_middleware::ClientWithMiddleware::from(reqwest::Client::new());
+    /// let resp = client.delete("http://httpbin.org/delete")
+    ///     .basic_auth("admin", Some("good password"))
+    ///     .send()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn basic_auth<U, P>(self, username: U, password: Option<P>) -> Self
     where
         U: Display,
@@ -233,6 +262,7 @@ impl RequestBuilder {
         }
     }
 
+    /// Enable HTTP bearer authentication.
     pub fn bearer_auth<T>(self, token: T) -> Self
     where
         T: Display,
@@ -243,6 +273,7 @@ impl RequestBuilder {
         }
     }
 
+    /// Set the request body.
     pub fn body<T: Into<Body>>(self, body: T) -> Self {
         RequestBuilder {
             inner: self.inner.body(body),
@@ -250,7 +281,11 @@ impl RequestBuilder {
         }
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
+    /// Enables a request timeout.
+    ///
+    /// The timeout is applied from when the request starts connecting until the
+    /// response body has finished. It affects only this request and overrides
+    /// the timeout configured using `ClientBuilder::timeout()`.
     pub fn timeout(self, timeout: std::time::Duration) -> Self {
         RequestBuilder {
             inner: self.inner.timeout(timeout),
@@ -267,6 +302,24 @@ impl RequestBuilder {
         }
     }
 
+    /// Modify the query string of the URL.
+    ///
+    /// Modifies the URL of this request, adding the parameters provided.
+    /// This method appends and does not overwrite. This means that it can
+    /// be called multiple times and that existing query parameters are not
+    /// overwritten if the same key is used. The key will simply show up
+    /// twice in the query string.
+    /// Calling `.query(&[("foo", "a"), ("foo", "b")])` gives `"foo=a&foo=b"`.
+    ///
+    /// # Note
+    /// This method does not support serializing a single key-value
+    /// pair. Instead of using `.query(("key", "val"))`, use a sequence, such
+    /// as `.query(&[("key", "val")])`. It's also possible to serialize structs
+    /// and maps into a key-value pair.
+    ///
+    /// # Errors
+    /// This method will fail if the object you provide cannot be serialized
+    /// into a query string.
     pub fn query<T: Serialize + ?Sized>(self, query: &T) -> Self {
         RequestBuilder {
             inner: self.inner.query(query),
@@ -274,6 +327,33 @@ impl RequestBuilder {
         }
     }
 
+    /// Send a form body.
+    ///
+    /// Sets the body to the url encoded serialization of the passed value,
+    /// and also sets the `Content-Type: application/x-www-form-urlencoded`
+    /// header.
+    ///
+    /// ```rust
+    /// # use anyhow::Error;
+    /// # use std::collections::HashMap;
+    /// #
+    /// # async fn run() -> Result<(), Error> {
+    /// let mut params = HashMap::new();
+    /// params.insert("lang", "rust");
+    ///
+    /// let client = reqwest_middleware::ClientWithMiddleware::from(reqwest::Client::new());
+    /// let res = client.post("http://httpbin.org")
+    ///     .form(&params)
+    ///     .send()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// This method fails if the passed value cannot be serialized into
+    /// url encoded format
     pub fn form<T: Serialize + ?Sized>(self, form: &T) -> Self {
         RequestBuilder {
             inner: self.inner.form(form),
@@ -281,6 +361,16 @@ impl RequestBuilder {
         }
     }
 
+    /// Send a JSON body.
+    ///
+    /// # Optional
+    ///
+    /// This requires the optional `json` feature enabled.
+    ///
+    /// # Errors
+    ///
+    /// Serialization can fail if `T`'s implementation of `Serialize` decides to
+    /// fail, or if `T` contains a map with non-string keys.
     #[cfg(feature = "json")]
     #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
     pub fn json<T: Serialize + ?Sized>(self, json: &T) -> Self {
@@ -290,6 +380,15 @@ impl RequestBuilder {
         }
     }
 
+    /// Disable CORS on fetching the request.
+    ///
+    /// # WASM
+    ///
+    /// This option is only effective with WebAssembly target.
+    ///
+    /// The [request mode][mdn] will be set to 'no-cors'.
+    ///
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/Request/mode
     pub fn fetch_mode_no_cors(self) -> Self {
         RequestBuilder {
             inner: self.inner.fetch_mode_no_cors(),
@@ -297,10 +396,17 @@ impl RequestBuilder {
         }
     }
 
+    /// Build a `Request`, which can be inspected, modified and executed with
+    /// `ClientWithMiddleware::execute()`.
     pub fn build(self) -> reqwest::Result<Request> {
         self.inner.build()
     }
 
+    /// Build a `Request`, which can be inspected, modified and executed with
+    /// `ClientWithMiddleware::execute()`.
+    ///
+    /// This is similar to [`RequestBuilder::build()`], but also returns the
+    /// embedded `Client`.
     pub fn build_split(self) -> (ClientWithMiddleware, reqwest::Result<Request>) {
         let Self {
             inner,
@@ -328,6 +434,27 @@ impl RequestBuilder {
         &mut self.extensions
     }
 
+    /// Constructs the Request and sends it to the target URL, returning a
+    /// future Response.
+    ///
+    /// # Errors
+    ///
+    /// This method fails if there was an error while sending request,
+    /// redirect loop was detected or redirect limit was exhausted.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use anyhow::Error;
+    /// #
+    /// # async fn run() -> Result<(), Error> {
+    /// let response = reqwest_middleware::ClientWithMiddleware::from(reqwest::Client::new())
+    ///     .get("https://hyper.rs")
+    ///     .send()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn send(mut self) -> Result<Response> {
         let mut extensions = std::mem::take(self.extensions());
         let (client, req) = self.build_split();
@@ -338,6 +465,21 @@ impl RequestBuilder {
     ///
     /// `None` is returned if the RequestBuilder can not be cloned,
     /// i.e. if the request body is a stream.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use reqwest::Error;
+    /// #
+    /// # fn run() -> Result<(), Error> {
+    /// let client = reqwest_middleware::ClientWithMiddleware::from(reqwest::Client::new());
+    /// let builder = client.post("http://httpbin.org/post")
+    ///     .body("from a &str!");
+    /// let clone = builder.try_clone();
+    /// assert!(clone.is_some());
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn try_clone(&self) -> Option<Self> {
         self.inner.try_clone().map(|inner| RequestBuilder {
             inner,

--- a/reqwest-middleware/src/client.rs
+++ b/reqwest-middleware/src/client.rs
@@ -270,8 +270,8 @@ mod service {
         type Error = crate::Error;
         type Future = Pending;
 
-        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<()>> {
-            Poll::Ready(Ok(()))
+        fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
+            self.inner.poll_ready(cx).map_err(crate::Error::Reqwest)
         }
 
         fn call(&mut self, req: Request) -> Self::Future {
@@ -292,8 +292,8 @@ mod service {
         type Error = crate::Error;
         type Future = Pending;
 
-        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<()>> {
-            Poll::Ready(Ok(()))
+        fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
+            (&self.inner).poll_ready(cx).map_err(crate::Error::Reqwest)
         }
 
         fn call(&mut self, req: Request) -> Self::Future {

--- a/reqwest-middleware/src/lib.rs
+++ b/reqwest-middleware/src/lib.rs
@@ -8,7 +8,7 @@
 //! ```
 //! use reqwest::{Client, Request, Response};
 //! use reqwest_middleware::{ClientBuilder, Middleware, Next, Result};
-//! use task_local_extensions::Extensions;
+//! use http::Extensions;
 //!
 //! struct LoggingMiddleware;
 //!

--- a/reqwest-middleware/src/middleware.rs
+++ b/reqwest-middleware/src/middleware.rs
@@ -96,7 +96,7 @@ impl<'a> Next<'a> {
     ) -> BoxFuture<'a, Result<Response>> {
         if let Some((current, rest)) = self.middlewares.split_first() {
             self.middlewares = rest;
-            Box::pin(current.handle(req, extensions, self))
+            current.handle(req, extensions, self)
         } else {
             Box::pin(async move { self.client.execute(req).await.map_err(Error::from) })
         }

--- a/reqwest-middleware/src/middleware.rs
+++ b/reqwest-middleware/src/middleware.rs
@@ -1,6 +1,6 @@
+use http::Extensions;
 use reqwest::{Client, Request, Response};
 use std::sync::Arc;
-use task_local_extensions::Extensions;
 
 use crate::error::{Error, Result};
 
@@ -12,7 +12,7 @@ use crate::error::{Error, Result};
 /// ```
 /// use reqwest::{Client, Request, Response};
 /// use reqwest_middleware::{ClientBuilder, Middleware, Next, Result};
-/// use task_local_extensions::Extensions;
+/// use http::Extensions;
 ///
 /// struct TransparentMiddleware;
 ///

--- a/reqwest-middleware/src/middleware.rs
+++ b/reqwest-middleware/src/middleware.rs
@@ -1,6 +1,5 @@
 use http::Extensions;
 use reqwest::{Client, Request, Response};
-use std::sync::Arc;
 
 use crate::error::{Error, Result};
 
@@ -74,7 +73,7 @@ where
 #[derive(Clone)]
 pub struct Next<'a> {
     client: &'a Client,
-    middlewares: &'a [Arc<dyn Middleware>],
+    middlewares: &'a [Box<dyn Middleware>],
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -83,7 +82,7 @@ pub type BoxFuture<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output = T
 pub type BoxFuture<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output = T> + 'a>>;
 
 impl<'a> Next<'a> {
-    pub(crate) fn new(client: &'a Client, middlewares: &'a [Arc<dyn Middleware>]) -> Self {
+    pub(crate) fn new(client: &'a Client, middlewares: &'a [Box<dyn Middleware>]) -> Self {
         Next {
             client,
             middlewares,

--- a/reqwest-middleware/src/req_init.rs
+++ b/reqwest-middleware/src/req_init.rs
@@ -32,14 +32,14 @@ where
     }
 }
 
-/// A middleware that inserts the value into the [`Extensions`](task_local_extensions::Extensions) during the call.
+/// A middleware that inserts the value into the [`Extensions`](http::Extensions) during the call.
 ///
 /// This is a good way to inject extensions to middleware deeper in the stack
 ///
 /// ```
 /// use reqwest::{Client, Request, Response};
 /// use reqwest_middleware::{ClientBuilder, Middleware, Next, Result, Extension};
-/// use task_local_extensions::Extensions;
+/// use http::Extensions;
 ///
 /// #[derive(Clone)]
 /// struct LogName(&'static str);

--- a/reqwest-retry/CHANGELOG.md
+++ b/reqwest-retry/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Breaking changes
+- Updated `reqwest-middleware` to `0.3.0`.
+
 ## [0.3.0] - 2023-09-07
 ### Changed
 - `retry-policies` upgraded to 0.2.0

--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-retry"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Retry middleware for reqwest."
@@ -10,20 +10,19 @@ keywords = ["reqwest", "http", "middleware", "retry"]
 categories = ["web-programming::http-client"]
 
 [dependencies]
-reqwest-middleware = { version = "0.2.0", path = "../reqwest-middleware" }
+reqwest-middleware = { version = "0.3.0", path = "../reqwest-middleware" }
 
 anyhow = "1.0.0"
 async-trait = "0.1.51"
 chrono = { version = "0.4.19", features = ["clock"], default-features = false }
 futures = "0.3.0"
-http = "0.2.0"
-reqwest = { version = "0.11.0", default-features = false }
+http = "1.0"
+reqwest = { version = "0.12.0", default-features = false }
 retry-policies = "0.3.0"
-task-local-extensions = "0.1.4"
 tracing = "0.1.26"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-hyper = "0.14.0"
+hyper = "1.0"
 tokio = { version = "1.6.0", features = ["time"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -34,5 +33,5 @@ getrandom = { version = "0.2.0", features = ["js"] }
 [dev-dependencies]
 paste = "1.0.0"
 tokio = { version = "1.0.0", features = ["full"] }
-wiremock = "0.5.0"
+wiremock = "0.6.0"
 futures = "0.3.0"

--- a/reqwest-retry/src/middleware.rs
+++ b/reqwest-retry/src/middleware.rs
@@ -3,10 +3,10 @@ use crate::retryable_strategy::RetryableStrategy;
 use crate::{retryable::Retryable, retryable_strategy::DefaultRetryableStrategy};
 use anyhow::anyhow;
 use chrono::Utc;
+use http::Extensions;
 use reqwest::{Request, Response};
 use reqwest_middleware::{Error, Middleware, Next, Result};
 use retry_policies::RetryPolicy;
-use task_local_extensions::Extensions;
 
 /// `RetryTransientMiddleware` offers retry logic for requests that fail in a transient manner
 /// and can be safely executed again.

--- a/reqwest-retry/src/retryable_strategy.rs
+++ b/reqwest-retry/src/retryable_strategy.rs
@@ -18,7 +18,7 @@ use reqwest_middleware::Error;
 /// use reqwest_retry::{default_on_request_failure, policies::ExponentialBackoff, Retryable, RetryableStrategy, RetryTransientMiddleware};
 /// use reqwest::{Request, Response};
 /// use reqwest_middleware::{ClientBuilder, Middleware, Next, Result};
-/// use task_local_extensions::Extensions;
+/// use http::Extensions;
 ///
 /// // Log each request to show that the requests will be retried
 /// struct LoggingMiddleware;

--- a/reqwest-tracing/CHANGELOG.md
+++ b/reqwest-tracing/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking changes
+- Updated `reqwest-middleware` to `0.3.0`.
+- Removed support for `opentelemetry` 0.13 to 0.19
+
+### Changed
+- opentelemetry features are now additive.
+
 ## [0.4.8] - 2024-03-11
 
 ### Added

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -10,11 +10,7 @@ keywords = ["reqwest", "http", "middleware", "opentelemetry", "tracing"]
 categories = ["web-programming::http-client"]
 
 [features]
-opentelemetry_0_16 = ["opentelemetry_0_16_pkg", "tracing-opentelemetry_0_16_pkg"]
-opentelemetry_0_17 = ["opentelemetry_0_17_pkg", "tracing-opentelemetry_0_17_pkg"]
-opentelemetry_0_18 = ["opentelemetry_0_18_pkg", "tracing-opentelemetry_0_18_pkg"]
-opentelemetry_0_19 = ["opentelemetry_0_19_pkg", "tracing-opentelemetry_0_19_pkg"]
-opentelemetry_0_20 = ["opentelemetry_0_20_pkg", "tracing-opentelemetry_0_20_pkg"]
+opentelemetry_0_20 = ["opentelemetry_0_20_pkg", "tracing-opentelemetry_0_21_pkg"]
 opentelemetry_0_21 = ["opentelemetry_0_21_pkg", "tracing-opentelemetry_0_22_pkg"]
 opentelemetry_0_22 = ["opentelemetry_0_22_pkg", "tracing-opentelemetry_0_23_pkg"]
 
@@ -29,18 +25,10 @@ http = "1"
 reqwest = { version = "0.12.0", default-features = false }
 tracing = "0.1.26"
 
-opentelemetry_0_16_pkg = { package = "opentelemetry", version = "0.16.0", optional = true }
-opentelemetry_0_17_pkg = { package = "opentelemetry", version = "0.17.0", optional = true }
-opentelemetry_0_18_pkg = { package = "opentelemetry", version = "0.18.0", optional = true }
-opentelemetry_0_19_pkg = { package = "opentelemetry", version = "0.19.0", optional = true }
 opentelemetry_0_20_pkg = { package = "opentelemetry", version = "0.20.0", optional = true }
 opentelemetry_0_21_pkg = { package = "opentelemetry", version = "0.21.0", optional = true }
 opentelemetry_0_22_pkg = { package = "opentelemetry", version = "0.22.0", optional = true }
-tracing-opentelemetry_0_16_pkg = { package = "tracing-opentelemetry", version = "0.16.0", optional = true }
-tracing-opentelemetry_0_17_pkg = { package = "tracing-opentelemetry", version = "0.17.0", optional = true }
-tracing-opentelemetry_0_18_pkg = { package = "tracing-opentelemetry", version = "0.18.0", optional = true }
-tracing-opentelemetry_0_19_pkg = { package = "tracing-opentelemetry", version = "0.19.0", optional = true }
-tracing-opentelemetry_0_20_pkg = { package = "tracing-opentelemetry", version = "0.20.0", optional = true }
+tracing-opentelemetry_0_21_pkg = { package = "tracing-opentelemetry", version = "0.21.0", optional = true }
 tracing-opentelemetry_0_22_pkg = { package = "tracing-opentelemetry", version = "0.22.0", optional = true }
 tracing-opentelemetry_0_23_pkg = { package = "tracing-opentelemetry", version = "0.23.0", optional = true }
 
@@ -51,6 +39,7 @@ getrandom = { version = "0.2.0", features = ["js"] }
 tokio = { version = "1.0.0", features = ["macros"] }
 tracing_subscriber_0_3 = { package = "tracing-subscriber", version = "0.3.0" }
 wiremock = "0.6.0"
+reqwest = { version = "0.12.0", features = ["rustls-tls"]}
 
 opentelemetry_sdk_0_21 = { package = "opentelemetry_sdk", version = "0.21.0", features = ["trace"] }
 opentelemetry_sdk_0_22 = { package = "opentelemetry_sdk", version = "0.22.0", features = ["trace"] }

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -37,7 +37,7 @@ getrandom = { version = "0.2.0", features = ["js"] }
 
 [dev-dependencies]
 tokio = { version = "1.0.0", features = ["macros"] }
-tracing_subscriber_0_3 = { package = "tracing-subscriber", version = "0.3.0" }
+tracing_subscriber = { package = "tracing-subscriber", version = "0.3.0" }
 wiremock = "0.6.0"
 reqwest = { version = "0.12.0", features = ["rustls-tls"]}
 

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -10,9 +10,6 @@ keywords = ["reqwest", "http", "middleware", "opentelemetry", "tracing"]
 categories = ["web-programming::http-client"]
 
 [features]
-opentelemetry_0_13 = ["opentelemetry_0_13_pkg", "tracing-opentelemetry_0_12_pkg"]
-opentelemetry_0_14 = ["opentelemetry_0_14_pkg", "tracing-opentelemetry_0_13_pkg"]
-opentelemetry_0_15 = ["opentelemetry_0_15_pkg", "tracing-opentelemetry_0_14_pkg"]
 opentelemetry_0_16 = ["opentelemetry_0_16_pkg", "tracing-opentelemetry_0_16_pkg"]
 opentelemetry_0_17 = ["opentelemetry_0_17_pkg", "tracing-opentelemetry_0_17_pkg"]
 opentelemetry_0_18 = ["opentelemetry_0_18_pkg", "tracing-opentelemetry_0_18_pkg"]
@@ -32,9 +29,6 @@ http = "1"
 reqwest = { version = "0.12.0", default-features = false }
 tracing = "0.1.26"
 
-opentelemetry_0_13_pkg = { package = "opentelemetry", version = "0.13.0", optional = true }
-opentelemetry_0_14_pkg = { package = "opentelemetry", version = "0.14.0", optional = true }
-opentelemetry_0_15_pkg = { package = "opentelemetry", version = "0.15.0", optional = true }
 opentelemetry_0_16_pkg = { package = "opentelemetry", version = "0.16.0", optional = true }
 opentelemetry_0_17_pkg = { package = "opentelemetry", version = "0.17.0", optional = true }
 opentelemetry_0_18_pkg = { package = "opentelemetry", version = "0.18.0", optional = true }
@@ -42,9 +36,6 @@ opentelemetry_0_19_pkg = { package = "opentelemetry", version = "0.19.0", option
 opentelemetry_0_20_pkg = { package = "opentelemetry", version = "0.20.0", optional = true }
 opentelemetry_0_21_pkg = { package = "opentelemetry", version = "0.21.0", optional = true }
 opentelemetry_0_22_pkg = { package = "opentelemetry", version = "0.22.0", optional = true }
-tracing-opentelemetry_0_12_pkg = { package = "tracing-opentelemetry", version = "0.12.0", optional = true }
-tracing-opentelemetry_0_13_pkg = { package = "tracing-opentelemetry", version = "0.13.0", optional = true }
-tracing-opentelemetry_0_14_pkg = { package = "tracing-opentelemetry", version = "0.14.0", optional = true }
 tracing-opentelemetry_0_16_pkg = { package = "tracing-opentelemetry", version = "0.16.0", optional = true }
 tracing-opentelemetry_0_17_pkg = { package = "tracing-opentelemetry", version = "0.17.0", optional = true }
 tracing-opentelemetry_0_18_pkg = { package = "tracing-opentelemetry", version = "0.18.0", optional = true }
@@ -58,7 +49,6 @@ getrandom = { version = "0.2.0", features = ["js"] }
 
 [dev-dependencies]
 tokio = { version = "1.0.0", features = ["macros"] }
-tracing_subscriber_0_2 = { package = "tracing-subscriber", version = "0.2.0" }
 tracing_subscriber_0_3 = { package = "tracing-subscriber", version = "0.3.0" }
 wiremock = "0.6.0"
 

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-tracing"
-version = "0.4.8"
+version = "0.5.0"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Opentracing middleware for reqwest."
@@ -23,13 +23,13 @@ opentelemetry_0_22 = ["opentelemetry_0_22_pkg", "tracing-opentelemetry_0_23_pkg"
 
 
 [dependencies]
-reqwest-middleware = { version = "0.2.0", path = "../reqwest-middleware" }
+reqwest-middleware = { version = "0.3.0", path = "../reqwest-middleware" }
 
 anyhow = "1.0.70"
 async-trait = "0.1.51"
-matchit = "0.7.0"
-reqwest = { version = "0.11.0", default-features = false }
-task-local-extensions = "0.1.4"
+matchit = "0.7.3"
+http = "1"
+reqwest = { version = "0.12.0", default-features = false }
 tracing = "0.1.26"
 
 opentelemetry_0_13_pkg = { package = "opentelemetry", version = "0.13.0", optional = true }
@@ -60,7 +60,7 @@ getrandom = { version = "0.2.0", features = ["js"] }
 tokio = { version = "1.0.0", features = ["macros"] }
 tracing_subscriber_0_2 = { package = "tracing-subscriber", version = "0.2.0" }
 tracing_subscriber_0_3 = { package = "tracing-subscriber", version = "0.3.0" }
-wiremock = "0.5.0"
+wiremock = "0.6.0"
 
 opentelemetry_sdk_0_21 = { package = "opentelemetry_sdk", version = "0.21.0", features = ["trace"] }
 opentelemetry_sdk_0_22 = { package = "opentelemetry_sdk", version = "0.22.0", features = ["trace"] }

--- a/reqwest-tracing/README.md
+++ b/reqwest-tracing/README.md
@@ -16,16 +16,15 @@ Attach `TracingMiddleware` to your client to automatically trace HTTP requests:
 # Cargo.toml
 # ...
 [dependencies]
-opentelemetry = "0.18"
-reqwest = "0.11"
-reqwest-middleware = "0.1.1"
-reqwest-retry = "0.1.1"
-reqwest-tracing = { version = "0.3.1", features = ["opentelemetry_0_18"] }
+opentelemetry = "0.22"
+reqwest = "0.12"
+reqwest-middleware = "0.3"
+reqwest-retry = "0.5"
+reqwest-tracing = { version = "0.5", features = ["opentelemetry_0_22"] }
 tokio = { version = "1.12.0", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"
-tracing-opentelemetry = "0.18"
+tracing-opentelemetry = "0.23"
 tracing-subscriber = "0.3"
-task-local-extensions = "0.1.4"
 ```
 
 ```rust,skip
@@ -89,12 +88,10 @@ an opentelemetry version feature:
 ```toml
 [dependencies]
 # ...
-reqwest-tracing = { version = "0.3.1", features = ["opentelemetry_0_18"] }
+reqwest-tracing = { version = "0.5.0", features = ["opentelemetry_0_22"] }
 ```
 
-Available opentelemetry features are `opentelemetry_0_22`, `opentelemetry_0_21`, `opentelemetry_0_20`,
-`opentelemetry_0_19`, `opentelemetry_0_18`, `opentelemetry_0_17`, `opentelemetry_0_16`,
-`opentelemetry_0_15`, `opentelemetry_0_14` and `opentelemetry_0_13`.
+Available opentelemetry features are `opentelemetry_0_22`, `opentelemetry_0_21`, and `opentelemetry_0_20`,
 
 #### License
 

--- a/reqwest-tracing/README.md
+++ b/reqwest-tracing/README.md
@@ -17,7 +17,7 @@ Attach `TracingMiddleware` to your client to automatically trace HTTP requests:
 # ...
 [dependencies]
 opentelemetry = "0.22"
-reqwest = "0.12"
+reqwest = { version = "0.12", features = ["rustls-tls"] }
 reqwest-middleware = "0.3"
 reqwest-retry = "0.5"
 reqwest-tracing = { version = "0.5", features = ["opentelemetry_0_22"] }

--- a/reqwest-tracing/README.md
+++ b/reqwest-tracing/README.md
@@ -34,7 +34,7 @@ use opentelemetry::sdk::export::trace::stdout;
 use reqwest::{Request, Response};
 use reqwest_middleware::{ClientBuilder, Result};
 use std::time::Instant;
-use task_local_extensions::Extensions;
+use http::Extensions;
 use tracing::Span;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::Registry;

--- a/reqwest-tracing/src/lib.rs
+++ b/reqwest-tracing/src/lib.rs
@@ -84,9 +84,6 @@
 
 mod middleware;
 #[cfg(any(
-    feature = "opentelemetry_0_13",
-    feature = "opentelemetry_0_14",
-    feature = "opentelemetry_0_15",
     feature = "opentelemetry_0_16",
     feature = "opentelemetry_0_17",
     feature = "opentelemetry_0_18",

--- a/reqwest-tracing/src/lib.rs
+++ b/reqwest-tracing/src/lib.rs
@@ -53,7 +53,7 @@
 //! Note that Opentelemetry tracks start and stop already, there is no need to have a custom builder like this.
 //! ```rust
 //! use reqwest_middleware::Result;
-//! use task_local_extensions::Extensions;
+//! use http::Extensions;
 //! use reqwest::{Request, Response};
 //! use reqwest_middleware::ClientBuilder;
 //! use reqwest_tracing::{

--- a/reqwest-tracing/src/lib.rs
+++ b/reqwest-tracing/src/lib.rs
@@ -84,10 +84,6 @@
 
 mod middleware;
 #[cfg(any(
-    feature = "opentelemetry_0_16",
-    feature = "opentelemetry_0_17",
-    feature = "opentelemetry_0_18",
-    feature = "opentelemetry_0_19",
     feature = "opentelemetry_0_20",
     feature = "opentelemetry_0_21",
     feature = "opentelemetry_0_22",

--- a/reqwest-tracing/src/middleware.rs
+++ b/reqwest-tracing/src/middleware.rs
@@ -46,15 +46,11 @@ where
 
         let outcome_future = async {
             #[cfg(any(
-                feature = "opentelemetry_0_16",
-                feature = "opentelemetry_0_17",
-                feature = "opentelemetry_0_18",
-                feature = "opentelemetry_0_19",
                 feature = "opentelemetry_0_20",
                 feature = "opentelemetry_0_21",
                 feature = "opentelemetry_0_22",
             ))]
-            let req = if !extensions.contains::<crate::DisableOtelPropagation>() {
+            let req = if extensions.get::<crate::DisableOtelPropagation>().is_none() {
                 // Adds tracing headers to the given request to propagate the OpenTelemetry context to downstream revivers of the request.
                 // Spans added by downstream consumers will be part of the same trace.
                 crate::otel::inject_opentelemetry_context_into_request(req)

--- a/reqwest-tracing/src/middleware.rs
+++ b/reqwest-tracing/src/middleware.rs
@@ -46,9 +46,6 @@ where
 
         let outcome_future = async {
             #[cfg(any(
-                feature = "opentelemetry_0_13",
-                feature = "opentelemetry_0_14",
-                feature = "opentelemetry_0_15",
                 feature = "opentelemetry_0_16",
                 feature = "opentelemetry_0_17",
                 feature = "opentelemetry_0_18",

--- a/reqwest-tracing/src/middleware.rs
+++ b/reqwest-tracing/src/middleware.rs
@@ -1,6 +1,6 @@
+use http::Extensions;
 use reqwest::{Request, Response};
 use reqwest_middleware::{Middleware, Next, Result};
-use task_local_extensions::Extensions;
 use tracing::Instrument;
 
 use crate::{DefaultSpanBackend, ReqwestOtelSpanBackend};

--- a/reqwest-tracing/src/otel.rs
+++ b/reqwest-tracing/src/otel.rs
@@ -3,28 +3,6 @@ use reqwest::Request;
 use std::str::FromStr;
 use tracing::Span;
 
-// #[cfg(feature = "opentelemetry_0_20")]
-// use opentelemetry_0_20_pkg as opentelemetry;
-
-// #[cfg(feature = "opentelemetry_0_21")]
-// use opentelemetry_0_21_pkg as opentelemetry;
-
-// #[cfg(feature = "opentelemetry_0_22")]
-// use opentelemetry_0_22_pkg as opentelemetry;
-
-// #[cfg(feature = "opentelemetry_0_20")]
-// pub use tracing_opentelemetry_0_21_pkg as tracing_opentelemetry;
-
-// #[cfg(feature = "opentelemetry_0_21")]
-// pub use tracing_opentelemetry_0_22_pkg as tracing_opentelemetry;
-
-// #[cfg(feature = "opentelemetry_0_22")]
-// pub use tracing_opentelemetry_0_23_pkg as tracing_opentelemetry;
-
-// use opentelemetry::global;
-// use opentelemetry::propagation::Injector;
-// use tracing_opentelemetry::OpenTelemetrySpanExt;
-
 /// Injects the given OpenTelemetry Context into a reqwest::Request headers to allow propagation downstream.
 pub fn inject_opentelemetry_context_into_request(mut request: Request) -> Request {
     #[cfg(feature = "opentelemetry_0_20")]
@@ -100,33 +78,7 @@ impl<'a> opentelemetry_0_22_pkg::propagation::Injector for RequestCarrier<'a> {
 mod test {
     use std::sync::OnceLock;
 
-    // #[cfg(feature = "opentelemetry_0_20")]
-    // use opentelemetry_0_20_pkg as opentelemetry;
-
-    // #[cfg(feature = "opentelemetry_0_21")]
-    // use opentelemetry_0_21_pkg as opentelemetry;
-
-    // #[cfg(feature = "opentelemetry_0_22")]
-    // use opentelemetry_0_22_pkg as opentelemetry;
-
-    // #[cfg(feature = "opentelemetry_0_20")]
-    // use tracing_opentelemetry_0_21_pkg as tracing_opentelemetry;
-
-    // #[cfg(feature = "opentelemetry_0_21")]
-    // use tracing_opentelemetry_0_22_pkg as tracing_opentelemetry;
-
-    // #[cfg(feature = "opentelemetry_0_22")]
-    // use tracing_opentelemetry_0_23_pkg as tracing_opentelemetry;
-
-    // use opentelemetry::global;
-
     use crate::{DisableOtelPropagation, TracingMiddleware};
-    // #[cfg(feature = "opentelemetry_0_20")]
-    // use opentelemetry::sdk::propagation::TraceContextPropagator;
-    // #[cfg(feature = "opentelemetry_0_21")]
-    // use opentelemetry_sdk_0_21::propagation::TraceContextPropagator;
-    // #[cfg(feature = "opentelemetry_0_22")]
-    // use opentelemetry_sdk_0_22::propagation::TraceContextPropagator;
     use reqwest::Response;
     use reqwest_middleware::{ClientBuilder, ClientWithMiddleware, Extension};
     use tracing::{info_span, Instrument, Level};

--- a/reqwest-tracing/src/otel.rs
+++ b/reqwest-tracing/src/otel.rs
@@ -3,15 +3,6 @@ use reqwest::Request;
 use std::str::FromStr;
 use tracing::Span;
 
-#[cfg(feature = "opentelemetry_0_13")]
-use opentelemetry_0_13_pkg as opentelemetry;
-
-#[cfg(feature = "opentelemetry_0_14")]
-use opentelemetry_0_14_pkg as opentelemetry;
-
-#[cfg(feature = "opentelemetry_0_15")]
-use opentelemetry_0_15_pkg as opentelemetry;
-
 #[cfg(feature = "opentelemetry_0_16")]
 use opentelemetry_0_16_pkg as opentelemetry;
 
@@ -32,15 +23,6 @@ use opentelemetry_0_21_pkg as opentelemetry;
 
 #[cfg(feature = "opentelemetry_0_22")]
 use opentelemetry_0_22_pkg as opentelemetry;
-
-#[cfg(feature = "opentelemetry_0_13")]
-pub use tracing_opentelemetry_0_12_pkg as tracing_opentelemetry;
-
-#[cfg(feature = "opentelemetry_0_14")]
-pub use tracing_opentelemetry_0_13_pkg as tracing_opentelemetry;
-
-#[cfg(feature = "opentelemetry_0_15")]
-pub use tracing_opentelemetry_0_14_pkg as tracing_opentelemetry;
 
 #[cfg(feature = "opentelemetry_0_16")]
 pub use tracing_opentelemetry_0_16_pkg as tracing_opentelemetry;
@@ -117,17 +99,7 @@ mod test {
     use reqwest::Response;
     use reqwest_middleware::{ClientBuilder, ClientWithMiddleware, Extension};
     use tracing::{info_span, Instrument, Level};
-    #[cfg(any(
-        feature = "opentelemetry_0_13",
-        feature = "opentelemetry_0_14",
-        feature = "opentelemetry_0_15"
-    ))]
-    use tracing_subscriber_0_2::{filter, layer::SubscriberExt, Registry};
-    #[cfg(not(any(
-        feature = "opentelemetry_0_13",
-        feature = "opentelemetry_0_14",
-        feature = "opentelemetry_0_15"
-    )))]
+
     use tracing_subscriber_0_3::{filter, layer::SubscriberExt, Registry};
     use wiremock::{matchers::any, Mock, MockServer, ResponseTemplate};
 

--- a/reqwest-tracing/src/otel.rs
+++ b/reqwest-tracing/src/otel.rs
@@ -83,7 +83,7 @@ mod test {
     use reqwest_middleware::{ClientBuilder, ClientWithMiddleware, Extension};
     use tracing::{info_span, Instrument, Level};
 
-    use tracing_subscriber_0_3::{filter, layer::SubscriberExt, Registry};
+    use tracing_subscriber::{filter, layer::SubscriberExt, Registry};
     use wiremock::{matchers::any, Mock, MockServer, ResponseTemplate};
 
     async fn make_echo_request_in_otel_context(client: ClientWithMiddleware) -> Response {

--- a/reqwest-tracing/src/otel.rs
+++ b/reqwest-tracing/src/otel.rs
@@ -3,18 +3,6 @@ use reqwest::Request;
 use std::str::FromStr;
 use tracing::Span;
 
-#[cfg(feature = "opentelemetry_0_16")]
-use opentelemetry_0_16_pkg as opentelemetry;
-
-#[cfg(feature = "opentelemetry_0_17")]
-use opentelemetry_0_17_pkg as opentelemetry;
-
-#[cfg(feature = "opentelemetry_0_18")]
-use opentelemetry_0_18_pkg as opentelemetry;
-
-#[cfg(feature = "opentelemetry_0_19")]
-use opentelemetry_0_19_pkg as opentelemetry;
-
 #[cfg(feature = "opentelemetry_0_20")]
 use opentelemetry_0_20_pkg as opentelemetry;
 
@@ -24,20 +12,8 @@ use opentelemetry_0_21_pkg as opentelemetry;
 #[cfg(feature = "opentelemetry_0_22")]
 use opentelemetry_0_22_pkg as opentelemetry;
 
-#[cfg(feature = "opentelemetry_0_16")]
-pub use tracing_opentelemetry_0_16_pkg as tracing_opentelemetry;
-
-#[cfg(feature = "opentelemetry_0_17")]
-pub use tracing_opentelemetry_0_17_pkg as tracing_opentelemetry;
-
-#[cfg(feature = "opentelemetry_0_18")]
-pub use tracing_opentelemetry_0_18_pkg as tracing_opentelemetry;
-
-#[cfg(feature = "opentelemetry_0_19")]
-pub use tracing_opentelemetry_0_19_pkg as tracing_opentelemetry;
-
 #[cfg(feature = "opentelemetry_0_20")]
-pub use tracing_opentelemetry_0_20_pkg as tracing_opentelemetry;
+pub use tracing_opentelemetry_0_21_pkg as tracing_opentelemetry;
 
 #[cfg(feature = "opentelemetry_0_21")]
 pub use tracing_opentelemetry_0_22_pkg as tracing_opentelemetry;
@@ -90,7 +66,7 @@ mod test {
 
     use super::*;
     use crate::{DisableOtelPropagation, TracingMiddleware};
-    #[cfg(not(any(feature = "opentelemetry_0_22", feature = "opentelemetry_0_21")))]
+    #[cfg(feature = "opentelemetry_0_20")]
     use opentelemetry::sdk::propagation::TraceContextPropagator;
     #[cfg(feature = "opentelemetry_0_21")]
     use opentelemetry_sdk_0_21::propagation::TraceContextPropagator;
@@ -107,19 +83,6 @@ mod test {
         static TELEMETRY: OnceLock<()> = OnceLock::new();
 
         TELEMETRY.get_or_init(|| {
-            #[cfg(all(
-                not(feature = "opentelemetry_0_20"),
-                not(feature = "opentelemetry_0_21"),
-                not(feature = "opentelemetry_0_22")
-            ))]
-            let tracer = opentelemetry::sdk::export::trace::stdout::new_pipeline()
-                .with_writer(std::io::sink())
-                .install_simple();
-            #[cfg(any(
-                feature = "opentelemetry_0_20",
-                feature = "opentelemetry_0_21",
-                feature = "opentelemetry_0_22"
-            ))]
             let tracer = {
                 use opentelemetry::trace::TracerProvider;
                 #[cfg(feature = "opentelemetry_0_20")]

--- a/reqwest-tracing/src/reqwest_otel_span_builder.rs
+++ b/reqwest-tracing/src/reqwest_otel_span_builder.rs
@@ -4,7 +4,7 @@ use matchit::Router;
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::{Request, Response, StatusCode as RequestStatusCode, Url};
 use reqwest_middleware::{Error, Result};
-use task_local_extensions::Extensions;
+use http::Extensions;
 use tracing::{warn, Span};
 
 use crate::reqwest_otel_span;

--- a/reqwest-tracing/src/reqwest_otel_span_macro.rs
+++ b/reqwest-tracing/src/reqwest_otel_span_macro.rs
@@ -31,7 +31,7 @@
 ///
 /// ```rust
 /// use reqwest_middleware::Result;
-/// use task_local_extensions::Extensions;
+/// use http::Extensions;
 /// use reqwest::{Request, Response};
 /// use reqwest_tracing::{
 ///     default_on_request_end, reqwest_otel_span, ReqwestOtelSpanBackend


### PR DESCRIPTION
reqwest 0.12 update necessarily causes a major version change here. Might as well break more things while we're at it

<!-- Please explain the changes you made -->

- update reqwest and http crates
- remove task_local_extensions in favour of http::Extensions
- remove older opentelemetry packages (over 1 year old)
- make otel features additive

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/reqwest-middleware/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CHANGELOG.md
-->
