### PR TITLE
Re-introduce default json + multipart features to reqwest

### DIFF
--- a/reqwest-middleware/Cargo.toml
+++ b/reqwest-middleware/Cargo.toml
@@ -18,7 +18,7 @@ json = ["reqwest/json"]
 anyhow = "1.0.0"
 async-trait = "0.1.51"
 http = "1.0.0"
-reqwest = { version = "0.12.0", default-features = false }
+reqwest = { version = "0.12.0", default-features = false, features = ["json", "multipart"] }
 serde = "1.0.106"
 thiserror = "1.0.21"
 tower-service = "0.3.0"


### PR DESCRIPTION
to allow .json() etc on RequestBuilders

think this should probably not be removed in https://github.com/TrueLayer/reqwest-middleware/commit/60212ae4510a7cabaa7fceb6ca60cc48a7829296# and breaks a couple of things downstream