### PR TITLE
Fix missing LICENSE-* files in released crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Included license files in crates
+
 ## [0.3.0] - 2024-04-10
 
 ### Breaking changes

--- a/reqwest-middleware/LICENSE-APACHE
+++ b/reqwest-middleware/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/reqwest-middleware/LICENSE-MIT
+++ b/reqwest-middleware/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/reqwest-retry/LICENSE-APACHE
+++ b/reqwest-retry/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/reqwest-retry/LICENSE-MIT
+++ b/reqwest-retry/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/reqwest-tracing/LICENSE-APACHE
+++ b/reqwest-tracing/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/reqwest-tracing/LICENSE-MIT
+++ b/reqwest-tracing/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
<!-- Please explain the changes you made -->
This PR adds symbolic links to the top-level `LICENSE-MIT`/`LICENSE-APACHE` files in all three crates (`reqwest-middleware`, `reqwest-retry`, and `reqwest-tracing`), which ensures that these license files appear in the published crates as required by the chosen license terms.

Before this PR, using `reqwest-retry` as an example:

```
gh repo clone TrueLayer/reqwest-middleware
cd reqwest-middleware/reqwest-retry
cargo publish --dry-run
tar -tzvf ../target/package/reqwest-retry-0.5.0.crate
```

(no license file appears in the output)

After this PR:

```
[…]
-rw-r--r-- 0/0            9723 2006-07-23 21:21 reqwest-retry-0.5.0/LICENSE-APACHE
-rw-r--r-- 0/0            1066 2006-07-23 21:21 reqwest-retry-0.5.0/LICENSE-MIT
[…]
```

Note that the symbolic links are resolved by `cargo publish`, and regular files appear in the crates.

A follow-up commit in this PR adds a changelog entry.

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/reqwest-middleware/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CHANGELOG.md
-->