### PR TITLE
Fix logging of `User-Agent` header in `reqwest-tracing`

### DIFF
--- a/reqwest-tracing/src/reqwest_otel_span_macro.rs
+++ b/reqwest-tracing/src/reqwest_otel_span_macro.rs
@@ -125,7 +125,7 @@ macro_rules! reqwest_otel_span {
             let host_port = url.port_or_known_default().unwrap_or(0) as i64;
             let otel_name = $name.to_string();
             let header_default = &::http::HeaderValue::from_static("");
-            let user_agent = format!("{:?}", $request.headers().get("user_agent").unwrap_or(header_default)).replace('"', "");
+            let user_agent = format!("{:?}", $request.headers().get("user-agent").unwrap_or(header_default)).replace('"', "");
 
             macro_rules! request_span {
                 ($lvl:expr) => {


### PR DESCRIPTION
`reqwest` is case-insensitive when it comes to headers, but `-` doesn't get replaced with a `_`.