### PR TITLE
[BOT-272] ClientBuilder extend convenience function

### DIFF
--- a/reqwest-middleware/src/client.rs
+++ b/reqwest-middleware/src/client.rs
@@ -34,8 +34,10 @@ impl ClientBuilder {
     /// Convenience method to extend a ClientBuilder instance by appending
     /// the middleware and initialiser stacks from a ClientwithMiddleware
     pub fn extend(mut self, client_with_middleware: ClientWithMiddleware) -> Self {
-        self.middleware_stack.append(&mut client_with_middleware.middleware_stack.into_vec());
-        self.initialiser_stack.append(&mut client_with_middleware.initialiser_stack.into_vec());
+        self.middleware_stack
+            .append(&mut client_with_middleware.middleware_stack.into_vec());
+        self.initialiser_stack
+            .append(&mut client_with_middleware.initialiser_stack.into_vec());
         self
     }
 

--- a/reqwest-middleware/src/client.rs
+++ b/reqwest-middleware/src/client.rs
@@ -31,14 +31,14 @@ impl ClientBuilder {
         }
     }
 
-    /// Convenience method to extend a ClientBuilder instance by appending
-    /// the middleware and initialiser stacks from a ClientwithMiddleware
-    pub fn extend(mut self, client_with_middleware: ClientWithMiddleware) -> Self {
-        self.middleware_stack
-            .append(&mut client_with_middleware.middleware_stack.into_vec());
-        self.initialiser_stack
-            .append(&mut client_with_middleware.initialiser_stack.into_vec());
-        self
+    /// Convenience method to create a ClientBuilder
+    /// from an existing ClientWithMiddleware instance
+    pub fn from_client(client_with_middleware: ClientWithMiddleware) -> Self {
+        Self {
+            client: client_with_middleware.inner,
+            middleware_stack: client_with_middleware.middleware_stack.into_vec(),
+            initialiser_stack: client_with_middleware.initialiser_stack.into_vec(),
+        }
     }
 
     /// Convenience method to attach middleware.

--- a/reqwest-middleware/src/client.rs
+++ b/reqwest-middleware/src/client.rs
@@ -31,7 +31,7 @@ impl ClientBuilder {
         }
     }
 
-    /// Convenience method to create a ClientBuilder
+    /// This method allows creating a ClientBuilder
     /// from an existing ClientWithMiddleware instance
     pub fn from_client(client_with_middleware: ClientWithMiddleware) -> Self {
         Self {

--- a/reqwest-middleware/src/client.rs
+++ b/reqwest-middleware/src/client.rs
@@ -31,6 +31,14 @@ impl ClientBuilder {
         }
     }
 
+    /// Convenience method to extend a ClientBuilder instance by appending
+    /// the middleware and initialiser stacks from a ClientwithMiddleware
+    pub fn extend(mut self, client_with_middleware: ClientWithMiddleware) -> Self {
+        self.middleware_stack.append(&mut client_with_middleware.middleware_stack.into_vec());
+        self.initialiser_stack.append(&mut client_with_middleware.initialiser_stack.into_vec());
+        self
+    }
+
     /// Convenience method to attach middleware.
     ///
     /// If you need to keep a reference to the middleware after attaching, use [`with_arc`].


### PR DESCRIPTION
<!-- Please explain the changes you made -->

This pull request adds a new `extend` function to the `ClientBuilder` which takes a `ClientWithMiddleware` instance and appends its middleware and initialiser stacks to the `ClientBuilder` instance it's being called on.

This is very convenient when `reqwest_middleware` is being used on libraries that accept a `ClientWithMiddleware`, but need to append their own middlewares to the client that's being passed down from the app.

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/reqwest-middleware/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CHANGELOG.md
-->
