### PR TITLE
Regex whitelist feature

### DIFF
--- a/reqwest-retry/CHANGELOG.md
+++ b/reqwest-retry/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added `regex` feature to
 - Added `with_retry_log_level` to `RetryTransientMiddleware`
 
 ## [0.5.0] - 2024-04-10

--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -20,6 +20,7 @@ http = "1.0"
 reqwest = { version = "0.12.0", default-features = false }
 retry-policies = "0.3.0"
 tracing = "0.1.26"
+regex = { version = "1.10.4", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 hyper = "1.0"
@@ -35,3 +36,6 @@ paste = "1.0.0"
 tokio = { version = "1.0.0", features = ["full"] }
 wiremock = "0.6.0"
 futures = "0.3.0"
+
+[features]
+regex = ["dep:regex"]


### PR DESCRIPTION
Adds a regex set matching feature so that if the request fails and the url matches against the provided `whitelist` pattern - it will be retried, otherwise not.

Example:
```rust
let whitelist = regex::RegexSet::new(vec!["foo", "bar"]).unwrap();
let reqwest_client = Client::builder().build().unwrap();
let client = ClientBuilder::new(reqwest_client)
    .with(RetryTransientMiddleware::new_with_policy(...).with_whitelist(whitelist))
    .build();

let resp = client
        .get("127.0.0.1/foo")
        .send()
        .await
        .expect("call failed"); // Will be retried if failed according to policy

let resp = client
        .get("127.0.0.1/bar")
        .send()
        .await
        .expect("call failed"); // Will be retried if failed according to policy
 
 let resp = client
        .get("127.0.0.1/something")
        .send()
        .await
        .expect("call failed");  // Will NOT be retried because the url does not match regex

```
