### PR TITLE
different error handling for chrono::TimeDelta::to_std

### DIFF
--- a/reqwest-retry/src/middleware.rs
+++ b/reqwest-retry/src/middleware.rs
@@ -159,8 +159,8 @@ where
                     let retry_decision = self.retry_policy.should_retry(start_time, n_past_retries);
                     if let retry_policies::RetryDecision::Retry { execute_after } = retry_decision {
                         let duration = (execute_after - Utc::now())
-                            .to_std()
-                            .map_err(Error::middleware)?;
+                            .to_std() // This fails if duration is negative
+                            .unwrap_or_else(|_| Default::default());
                         // Sleep the requested amount before we try again.
                         log_retry!(
                             self.retry_log_level,


### PR DESCRIPTION
i got an error in my logs from this and it generated an alert, so i looked into it

my theory is that, my timeouts are on the order of milliseconds, but i have full jitter (the default), and by chance the resulting backoff computed was very small, like microseconds. then because retry policy returns a datetime instead of a duration, we end up computing Utc::now (a second time) to go back to a duration, and this second time the result was negative because some time had passed.

instead of returning a fatal error in this case, we should just continue retrying imo, and sleeping for 0 seconds seems fine.

lmk what you think, i know this is very niche
