### PR TITLE
Re-export reqwest crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added support for `opentelemetry` version `0.23`.
+- Added re-export of `reqwest`.
 
 ## [0.3.1]
 

--- a/reqwest-middleware/src/lib.rs
+++ b/reqwest-middleware/src/lib.rs
@@ -58,3 +58,4 @@ pub use client::{ClientBuilder, ClientWithMiddleware, RequestBuilder};
 pub use error::{Error, Result};
 pub use middleware::{Middleware, Next};
 pub use req_init::{Extension, RequestInitialiser};
+pub use reqwest;


### PR DESCRIPTION
In a large project, it's not unheard of for multiple mutually-incompatible versions of a major crate like `reqwest` to end up in the mix.  By re-exporting the version of `reqwest` used by `reqwest-middleware`, we can be sure we're referring to the *correct* `reqwest`, rather than some other, incompatible, `reqwest`.

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/reqwest-middleware/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CHANGELOG.md
-->
