### PR TITLE
Update RetryTransientMiddleware to allow any RetryableStrategy

### DIFF
--- a/reqwest-retry/src/middleware.rs
+++ b/reqwest-retry/src/middleware.rs
@@ -65,7 +65,7 @@ macro_rules! log_retry {
 /// source directly, avoiding the issue of streaming requests not being clonable.
 pub struct RetryTransientMiddleware<
     T: RetryPolicy + Send + Sync + 'static,
-    R: RetryableStrategy + Send + Sync + 'static = DefaultRetryableStrategy,
+    R: RetryableStrategy + Send + Sync + 'static,
 > {
     retry_policy: T,
     retryable_strategy: R,


### PR DESCRIPTION
[`RetryTransientMiddleware`](https://github.com/TrueLayer/reqwest-middleware/blob/88dbfe67fbf56aecf29de9bc0b23a0abc72e3f29/reqwest-retry/src/middleware.rs#L68)'s type bounds are configured to only allow `DefaultRetryableStrategy`. This change allows any impl of `RetryableStrategy`
