### PR TITLE
Add feature flag for deprecated fields

### DIFF
--- a/reqwest-tracing/CHANGELOG.md
+++ b/reqwest-tracing/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2024-07-15
+
+### Added
+- Added support for `opentelemetry` 0.13 to 0.19 through the `deprecated_attributes` flag.
+
 ## [0.5.1] - 2024-06-28
 
 ### Added

--- a/reqwest-tracing/CHANGELOG.md
+++ b/reqwest-tracing/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.2] - 2024-07-15
 
 ### Added
-- Added support for `opentelemetry` 0.13 to 0.19 through the `deprecated_attributes` flag.
+- Added feature flag, `deprecated_attributes`, for emitting [deprecated opentelemetry HTTP attributes](https://opentelemetry.io/docs/specs/semconv/http/migration-guide/) alongside the stable ones used by default
 
 ## [0.5.1] - 2024-06-28
 

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-tracing"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Opentracing middleware for reqwest."

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -10,11 +10,23 @@ keywords = ["reqwest", "http", "middleware", "opentelemetry", "tracing"]
 categories = ["web-programming::http-client"]
 
 [features]
-opentelemetry_0_20 = ["opentelemetry_0_20_pkg", "tracing-opentelemetry_0_21_pkg"]
-opentelemetry_0_21 = ["opentelemetry_0_21_pkg", "tracing-opentelemetry_0_22_pkg"]
-opentelemetry_0_22 = ["opentelemetry_0_22_pkg", "tracing-opentelemetry_0_23_pkg"]
-opentelemetry_0_23 = ["opentelemetry_0_23_pkg", "tracing-opentelemetry_0_24_pkg"]
-
+opentelemetry_0_20 = [
+    "opentelemetry_0_20_pkg",
+    "tracing-opentelemetry_0_21_pkg",
+]
+opentelemetry_0_21 = [
+    "opentelemetry_0_21_pkg",
+    "tracing-opentelemetry_0_22_pkg",
+]
+opentelemetry_0_22 = [
+    "opentelemetry_0_22_pkg",
+    "tracing-opentelemetry_0_23_pkg",
+]
+opentelemetry_0_23 = [
+    "opentelemetry_0_23_pkg",
+    "tracing-opentelemetry_0_24_pkg",
+]
+deprecated-fields = []
 
 [dependencies]
 reqwest-middleware = { version = "0.3.0", path = "../reqwest-middleware" }
@@ -42,12 +54,26 @@ getrandom = { version = "0.2.0", features = ["js"] }
 tokio = { version = "1.0.0", features = ["macros"] }
 tracing_subscriber = { package = "tracing-subscriber", version = "0.3.0" }
 wiremock = "0.6.0"
-reqwest = { version = "0.12.0", features = ["rustls-tls"]}
+reqwest = { version = "0.12.0", features = ["rustls-tls"] }
 
-opentelemetry_sdk_0_21 = { package = "opentelemetry_sdk", version = "0.21.0", features = ["trace"] }
-opentelemetry_sdk_0_22 = { package = "opentelemetry_sdk", version = "0.22.0", features = ["trace"] }
-opentelemetry_sdk_0_23 = { package = "opentelemetry_sdk", version = "0.23.0", features = ["trace"] }
-opentelemetry_stdout_0_1 = { package = "opentelemetry-stdout", version = "0.1.0", features = ["trace"] }
-opentelemetry_stdout_0_2 = { package = "opentelemetry-stdout", version = "0.2.0", features = ["trace"] }
-opentelemetry_stdout_0_3 = { package = "opentelemetry-stdout", version = "0.3.0", features = ["trace"] }
-opentelemetry_stdout_0_4 = { package = "opentelemetry-stdout", version = "0.4.0", features = ["trace"] }
+opentelemetry_sdk_0_21 = { package = "opentelemetry_sdk", version = "0.21.0", features = [
+    "trace",
+] }
+opentelemetry_sdk_0_22 = { package = "opentelemetry_sdk", version = "0.22.0", features = [
+    "trace",
+] }
+opentelemetry_sdk_0_23 = { package = "opentelemetry_sdk", version = "0.23.0", features = [
+    "trace",
+] }
+opentelemetry_stdout_0_1 = { package = "opentelemetry-stdout", version = "0.1.0", features = [
+    "trace",
+] }
+opentelemetry_stdout_0_2 = { package = "opentelemetry-stdout", version = "0.2.0", features = [
+    "trace",
+] }
+opentelemetry_stdout_0_3 = { package = "opentelemetry-stdout", version = "0.3.0", features = [
+    "trace",
+] }
+opentelemetry_stdout_0_4 = { package = "opentelemetry-stdout", version = "0.4.0", features = [
+    "trace",
+] }

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -14,6 +14,9 @@ opentelemetry_0_20 = ["opentelemetry_0_20_pkg", "tracing-opentelemetry_0_21_pkg"
 opentelemetry_0_21 = ["opentelemetry_0_21_pkg", "tracing-opentelemetry_0_22_pkg"]
 opentelemetry_0_22 = ["opentelemetry_0_22_pkg", "tracing-opentelemetry_0_23_pkg"]
 opentelemetry_0_23 = ["opentelemetry_0_23_pkg", "tracing-opentelemetry_0_24_pkg"]
+# This feature ensures that both the old (deprecated) and new attributes are published simultaneously.
+# By doing so, we maintain backward compatibility, allowing existing code that relies on the old attributes
+# to continue functioning while encouraging the transition to the new attributes.
 deprecated_attributes = []
 
 [dependencies]

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -10,22 +10,10 @@ keywords = ["reqwest", "http", "middleware", "opentelemetry", "tracing"]
 categories = ["web-programming::http-client"]
 
 [features]
-opentelemetry_0_20 = [
-    "opentelemetry_0_20_pkg",
-    "tracing-opentelemetry_0_21_pkg",
-]
-opentelemetry_0_21 = [
-    "opentelemetry_0_21_pkg",
-    "tracing-opentelemetry_0_22_pkg",
-]
-opentelemetry_0_22 = [
-    "opentelemetry_0_22_pkg",
-    "tracing-opentelemetry_0_23_pkg",
-]
-opentelemetry_0_23 = [
-    "opentelemetry_0_23_pkg",
-    "tracing-opentelemetry_0_24_pkg",
-]
+opentelemetry_0_20 = ["opentelemetry_0_20_pkg", "tracing-opentelemetry_0_21_pkg"]
+opentelemetry_0_21 = ["opentelemetry_0_21_pkg", "tracing-opentelemetry_0_22_pkg"]
+opentelemetry_0_22 = ["opentelemetry_0_22_pkg", "tracing-opentelemetry_0_23_pkg"]
+opentelemetry_0_23 = ["opentelemetry_0_23_pkg", "tracing-opentelemetry_0_24_pkg"]
 deprecated-fields = []
 
 [dependencies]
@@ -55,25 +43,11 @@ tokio = { version = "1.0.0", features = ["macros"] }
 tracing_subscriber = { package = "tracing-subscriber", version = "0.3.0" }
 wiremock = "0.6.0"
 reqwest = { version = "0.12.0", features = ["rustls-tls"] }
+opentelemetry_sdk_0_21 = { package = "opentelemetry_sdk", version = "0.21.0", features = ["trace"] }
+opentelemetry_sdk_0_22 = { package = "opentelemetry_sdk", version = "0.22.0", features = ["trace"] }
+opentelemetry_sdk_0_23 = { package = "opentelemetry_sdk", version = "0.23.0", features = ["trace"] }
+opentelemetry_stdout_0_1 = { package = "opentelemetry-stdout", version = "0.1.0", features = ["trace"] }
+opentelemetry_stdout_0_2 = { package = "opentelemetry-stdout", version = "0.2.0", features = ["trace"] }
+opentelemetry_stdout_0_3 = { package = "opentelemetry-stdout", version = "0.3.0", features = ["trace"] }
+opentelemetry_stdout_0_4 = { package = "opentelemetry-stdout", version = "0.4.0", features = ["trace"] }
 
-opentelemetry_sdk_0_21 = { package = "opentelemetry_sdk", version = "0.21.0", features = [
-    "trace",
-] }
-opentelemetry_sdk_0_22 = { package = "opentelemetry_sdk", version = "0.22.0", features = [
-    "trace",
-] }
-opentelemetry_sdk_0_23 = { package = "opentelemetry_sdk", version = "0.23.0", features = [
-    "trace",
-] }
-opentelemetry_stdout_0_1 = { package = "opentelemetry-stdout", version = "0.1.0", features = [
-    "trace",
-] }
-opentelemetry_stdout_0_2 = { package = "opentelemetry-stdout", version = "0.2.0", features = [
-    "trace",
-] }
-opentelemetry_stdout_0_3 = { package = "opentelemetry-stdout", version = "0.3.0", features = [
-    "trace",
-] }
-opentelemetry_stdout_0_4 = { package = "opentelemetry-stdout", version = "0.4.0", features = [
-    "trace",
-] }

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -14,7 +14,7 @@ opentelemetry_0_20 = ["opentelemetry_0_20_pkg", "tracing-opentelemetry_0_21_pkg"
 opentelemetry_0_21 = ["opentelemetry_0_21_pkg", "tracing-opentelemetry_0_22_pkg"]
 opentelemetry_0_22 = ["opentelemetry_0_22_pkg", "tracing-opentelemetry_0_23_pkg"]
 opentelemetry_0_23 = ["opentelemetry_0_23_pkg", "tracing-opentelemetry_0_24_pkg"]
-deprecated-fields = []
+deprecated_attributes = []
 
 [dependencies]
 reqwest-middleware = { version = "0.3.0", path = "../reqwest-middleware" }
@@ -43,6 +43,7 @@ tokio = { version = "1.0.0", features = ["macros"] }
 tracing_subscriber = { package = "tracing-subscriber", version = "0.3.0" }
 wiremock = "0.6.0"
 reqwest = { version = "0.12.0", features = ["rustls-tls"] }
+
 opentelemetry_sdk_0_21 = { package = "opentelemetry_sdk", version = "0.21.0", features = ["trace"] }
 opentelemetry_sdk_0_22 = { package = "opentelemetry_sdk", version = "0.22.0", features = ["trace"] }
 opentelemetry_sdk_0_23 = { package = "opentelemetry_sdk", version = "0.23.0", features = ["trace"] }

--- a/reqwest-tracing/src/lib.rs
+++ b/reqwest-tracing/src/lib.rs
@@ -100,5 +100,10 @@ pub use reqwest_otel_span_builder::{
     SERVER_ADDRESS, SERVER_PORT, URL_FULL, URL_SCHEME, USER_AGENT_ORIGINAL,
 };
 
+#[cfg(feature = "deprecated_fields")]
+pub use reqwest_otel_span_builder::{
+    HTTP_HOST, HTTP_METHOD, HTTP_SCHEME, HTTP_STATUS_CODE, HTTP_URL, HTTP_USER_AGENT, NET_HOST_PORT,
+};
+
 #[doc(hidden)]
 pub mod reqwest_otel_span_macro;

--- a/reqwest-tracing/src/lib.rs
+++ b/reqwest-tracing/src/lib.rs
@@ -100,7 +100,7 @@ pub use reqwest_otel_span_builder::{
     SERVER_ADDRESS, SERVER_PORT, URL_FULL, URL_SCHEME, USER_AGENT_ORIGINAL,
 };
 
-#[cfg(feature = "deprecated_fields")]
+#[cfg(feature = "deprecated_attributes")]
 pub use reqwest_otel_span_builder::{
     HTTP_HOST, HTTP_METHOD, HTTP_SCHEME, HTTP_STATUS_CODE, HTTP_URL, HTTP_USER_AGENT, NET_HOST_PORT,
 };

--- a/reqwest-tracing/src/reqwest_otel_span_builder.rs
+++ b/reqwest-tracing/src/reqwest_otel_span_builder.rs
@@ -85,10 +85,7 @@ pub fn default_on_request_success(span: &Span, response: &Response) {
     if let Some(span_status) = span_status {
         span.record(OTEL_STATUS_CODE, span_status);
     }
-    #[cfg(not(feature = "deprecated_attributes"))]
-    {
-        span.record(HTTP_RESPONSE_STATUS_CODE, response.status().as_u16());
-    }
+    span.record(HTTP_RESPONSE_STATUS_CODE, response.status().as_u16());
     #[cfg(feature = "deprecated_attributes")]
     {
         span.record(HTTP_STATUS_CODE, response.status().as_u16());
@@ -106,10 +103,7 @@ pub fn default_on_request_failure(span: &Span, e: &Error) {
     span.record(ERROR_CAUSE_CHAIN, error_cause_chain.as_str());
     if let Error::Reqwest(e) = e {
         if let Some(status) = e.status() {
-            #[cfg(not(feature = "deprecated_attributes"))]
-            {
-                span.record(HTTP_RESPONSE_STATUS_CODE, status.as_u16());
-            }
+            span.record(HTTP_RESPONSE_STATUS_CODE, status.as_u16());
             #[cfg(feature = "deprecated_attributes")]
             {
                 span.record(HTTP_STATUS_CODE, status.as_u16());
@@ -164,14 +158,7 @@ pub struct SpanBackendWithUrl;
 impl ReqwestOtelSpanBackend for SpanBackendWithUrl {
     fn on_request_start(req: &Request, ext: &mut Extensions) -> Span {
         let name = default_span_name(req, ext);
-        #[cfg(not(feature = "deprecated_attributes"))]
-        {
-            reqwest_otel_span!(name = name, req, url.full = %remove_credentials(req.url()))
-        }
-        #[cfg(feature = "deprecated_attributes")]
-        {
-            reqwest_otel_span!(name = name, req, http.full = %remove_credentials(req.url()))
-        }
+        reqwest_otel_span!(name = name, req, url.full = %remove_credentials(req.url()))
     }
 
     fn on_request_end(span: &Span, outcome: &Result<Response>, _: &mut Extensions) {

--- a/reqwest-tracing/src/reqwest_otel_span_builder.rs
+++ b/reqwest-tracing/src/reqwest_otel_span_builder.rs
@@ -34,25 +34,25 @@ pub const ERROR_MESSAGE: &str = "error.message";
 pub const ERROR_CAUSE_CHAIN: &str = "error.cause_chain";
 
 /// The `http.method` field added to the span by [`reqwest_otel_span`]
-#[cfg(feature = "deprecated_fields")]
+#[cfg(feature = "deprecated_attributes")]
 pub const HTTP_METHOD: &str = "http.method";
 /// The `http.scheme` field added to the span by [`reqwest_otel_span`]
-#[cfg(feature = "deprecated_fields")]
+#[cfg(feature = "deprecated_attributes")]
 pub const HTTP_SCHEME: &str = "http.scheme";
 /// The `http.host` field added to the span by [`reqwest_otel_span`]
-#[cfg(feature = "deprecated_fields")]
+#[cfg(feature = "deprecated_attributes")]
 pub const HTTP_HOST: &str = "http.host";
 /// The `http.url` field added to the span by [`reqwest_otel_span`]
-#[cfg(feature = "deprecated_fields")]
+#[cfg(feature = "deprecated_attributes")]
 pub const HTTP_URL: &str = "http.url";
 /// The `host.port` field added to the span by [`reqwest_otel_span`]
-#[cfg(feature = "deprecated_fields")]
+#[cfg(feature = "deprecated_attributes")]
 pub const NET_HOST_PORT: &str = "net.host.port";
 /// The `http.status_code` field added to the span by [`reqwest_otel_span`]
-#[cfg(feature = "deprecated_fields")]
+#[cfg(feature = "deprecated_attributes")]
 pub const HTTP_STATUS_CODE: &str = "http.status_code";
 /// The `http.user_agent` added to the span by [`reqwest_otel_span`]
-#[cfg(feature = "deprecated_fields")]
+#[cfg(feature = "deprecated_attributes")]
 pub const HTTP_USER_AGENT: &str = "http.user_agent";
 
 /// [`ReqwestOtelSpanBackend`] allows you to customise the span attached by
@@ -85,11 +85,11 @@ pub fn default_on_request_success(span: &Span, response: &Response) {
     if let Some(span_status) = span_status {
         span.record(OTEL_STATUS_CODE, span_status);
     }
-    #[cfg(not(feature = "deprecated_fields"))]
+    #[cfg(not(feature = "deprecated_attributes"))]
     {
         span.record(HTTP_RESPONSE_STATUS_CODE, response.status().as_u16());
     }
-    #[cfg(feature = "deprecated_fields")]
+    #[cfg(feature = "deprecated_attributes")]
     {
         span.record(HTTP_STATUS_CODE, response.status().as_u16());
         span.record(HTTP_USER_AGENT, user_agent.as_str());
@@ -106,11 +106,11 @@ pub fn default_on_request_failure(span: &Span, e: &Error) {
     span.record(ERROR_CAUSE_CHAIN, error_cause_chain.as_str());
     if let Error::Reqwest(e) = e {
         if let Some(status) = e.status() {
-            #[cfg(not(feature = "deprecated_fields"))]
+            #[cfg(not(feature = "deprecated_attributes"))]
             {
                 span.record(HTTP_RESPONSE_STATUS_CODE, status.as_u16());
             }
-            #[cfg(feature = "deprecated_fields")]
+            #[cfg(feature = "deprecated_attributes")]
             {
                 span.record(HTTP_STATUS_CODE, status.as_u16());
             }
@@ -164,11 +164,11 @@ pub struct SpanBackendWithUrl;
 impl ReqwestOtelSpanBackend for SpanBackendWithUrl {
     fn on_request_start(req: &Request, ext: &mut Extensions) -> Span {
         let name = default_span_name(req, ext);
-        #[cfg(not(feature = "deprecated_fields"))]
+        #[cfg(not(feature = "deprecated_attributes"))]
         {
             reqwest_otel_span!(name = name, req, url.full = %remove_credentials(req.url()))
         }
-        #[cfg(feature = "deprecated_fields")]
+        #[cfg(feature = "deprecated_attributes")]
         {
             reqwest_otel_span!(name = name, req, http.full = %remove_credentials(req.url()))
         }

--- a/reqwest-tracing/src/reqwest_otel_span_macro.rs
+++ b/reqwest-tracing/src/reqwest_otel_span_macro.rs
@@ -127,6 +127,7 @@ macro_rules! reqwest_otel_span {
             let header_default = &::http::HeaderValue::from_static("");
             let user_agent = format!("{:?}", $request.headers().get("user-agent").unwrap_or(header_default)).replace('"', "");
 
+            #[cfg(not(feature = "deprecated_attributes"))]
             macro_rules! request_span {
                 ($lvl:expr) => {
                     $crate::reqwest_otel_span_macro::private::span!(
@@ -152,12 +153,27 @@ macro_rules! reqwest_otel_span {
             macro_rules! request_span {
                 ($lvl:expr) => {
                     $crate::reqwest_otel_span_macro::private::span!(
+                        $lvl,
+                        "HTTP request",
+                        http.request.method = %method,
+                        url.scheme = %scheme,
+                        server.address = %host,
+                        server.port = %host_port,
+                        user_agent.original = %user_agent,
+                        otel.kind = "client",
+                        otel.name = %otel_name,
+                        otel.status_code = tracing::field::Empty,
+                        http.response.status_code = tracing::field::Empty,
+                        error.message = tracing::field::Empty,
+                        error.cause_chain = tracing::field::Empty,
+                        // deprecrated attributes
                         http.method = %method,
                         http.scheme = %scheme,
                         http.host = %host,
                         net.host.port = %host_port,
                         http.user_agent = tracing::field::Empty,
                         http.status_code = tracing::field::Empty,
+                        $($field)*
                     )
                 }
             }

--- a/reqwest-tracing/src/reqwest_otel_span_macro.rs
+++ b/reqwest-tracing/src/reqwest_otel_span_macro.rs
@@ -127,6 +127,7 @@ macro_rules! reqwest_otel_span {
             let header_default = &::http::HeaderValue::from_static("");
             let user_agent = format!("{:?}", $request.headers().get("user-agent").unwrap_or(header_default)).replace('"', "");
 
+            #[cfg(not(feature = "deprecated_fields"))]
             macro_rules! request_span {
                 ($lvl:expr) => {
                     $crate::reqwest_otel_span_macro::private::span!(
@@ -141,6 +142,29 @@ macro_rules! reqwest_otel_span {
                         otel.name = %otel_name,
                         otel.status_code = tracing::field::Empty,
                         http.response.status_code = tracing::field::Empty,
+                        error.message = tracing::field::Empty,
+                        error.cause_chain = tracing::field::Empty,
+                        $($field)*
+                    )
+                }
+            }
+
+            #[cfg(feature = "deprecated_fields")]
+            macro_rules! request_span {
+                ($lvl:expr) => {
+                    $crate::reqwest_otel_span_macro::private::span!(
+                        $lvl,
+                        "HTTP request",
+                        http.method = %method,
+                        http.scheme = %scheme,
+                        http.host = %host,
+                        net.host.port = %host_port,
+                        user_agent.original = %user_agent,
+                        otel.kind = "client",
+                        otel.name = %otel_name,
+                        otel.status_code = tracing::field::Empty,
+                        http.user_agent = tracing::field::Empty,
+                        http.status_code = tracing::field::Empty,
                         error.message = tracing::field::Empty,
                         error.cause_chain = tracing::field::Empty,
                         $($field)*

--- a/reqwest-tracing/src/reqwest_otel_span_macro.rs
+++ b/reqwest-tracing/src/reqwest_otel_span_macro.rs
@@ -149,6 +149,7 @@ macro_rules! reqwest_otel_span {
                 }
             }
 
+            // With the deprecated attributes flag enabled, we publish both the old and new attributes.
             #[cfg(feature = "deprecated_attributes")]
             macro_rules! request_span {
                 ($lvl:expr) => {
@@ -166,7 +167,7 @@ macro_rules! reqwest_otel_span {
                         http.response.status_code = tracing::field::Empty,
                         error.message = tracing::field::Empty,
                         error.cause_chain = tracing::field::Empty,
-                        // deprecrated attributes
+                        // old attributes
                         http.method = %method,
                         http.scheme = %scheme,
                         http.host = %host,

--- a/reqwest-tracing/src/reqwest_otel_span_macro.rs
+++ b/reqwest-tracing/src/reqwest_otel_span_macro.rs
@@ -127,7 +127,6 @@ macro_rules! reqwest_otel_span {
             let header_default = &::http::HeaderValue::from_static("");
             let user_agent = format!("{:?}", $request.headers().get("user-agent").unwrap_or(header_default)).replace('"', "");
 
-            #[cfg(not(feature = "deprecated_attributes"))]
             macro_rules! request_span {
                 ($lvl:expr) => {
                     $crate::reqwest_otel_span_macro::private::span!(
@@ -153,21 +152,12 @@ macro_rules! reqwest_otel_span {
             macro_rules! request_span {
                 ($lvl:expr) => {
                     $crate::reqwest_otel_span_macro::private::span!(
-                        $lvl,
-                        "HTTP request",
                         http.method = %method,
                         http.scheme = %scheme,
                         http.host = %host,
                         net.host.port = %host_port,
-                        user_agent.original = %user_agent,
-                        otel.kind = "client",
-                        otel.name = %otel_name,
-                        otel.status_code = tracing::field::Empty,
                         http.user_agent = tracing::field::Empty,
                         http.status_code = tracing::field::Empty,
-                        error.message = tracing::field::Empty,
-                        error.cause_chain = tracing::field::Empty,
-                        $($field)*
                     )
                 }
             }

--- a/reqwest-tracing/src/reqwest_otel_span_macro.rs
+++ b/reqwest-tracing/src/reqwest_otel_span_macro.rs
@@ -127,7 +127,7 @@ macro_rules! reqwest_otel_span {
             let header_default = &::http::HeaderValue::from_static("");
             let user_agent = format!("{:?}", $request.headers().get("user-agent").unwrap_or(header_default)).replace('"', "");
 
-            #[cfg(not(feature = "deprecated_fields"))]
+            #[cfg(not(feature = "deprecated_attributes"))]
             macro_rules! request_span {
                 ($lvl:expr) => {
                     $crate::reqwest_otel_span_macro::private::span!(
@@ -149,7 +149,7 @@ macro_rules! reqwest_otel_span {
                 }
             }
 
-            #[cfg(feature = "deprecated_fields")]
+            #[cfg(feature = "deprecated_attributes")]
             macro_rules! request_span {
                 ($lvl:expr) => {
                     $crate::reqwest_otel_span_macro::private::span!(


### PR DESCRIPTION
This PR introduces a feature flag to `reqwest-middleware` that enables the old field names along with the new ones.