### PR TITLE
Reduce dependencies in reqwest-retry

### DIFF
--- a/reqwest-middleware/Cargo.toml
+++ b/reqwest-middleware/Cargo.toml
@@ -15,6 +15,7 @@ multipart = ["reqwest/multipart"]
 json = ["reqwest/json"]
 charset = ["reqwest/charset"]
 http2 = ["reqwest/http2"]
+rustls-tls = ["reqwest/rustls-tls"]
 
 [dependencies]
 anyhow = "1.0.0"

--- a/reqwest-middleware/Cargo.toml
+++ b/reqwest-middleware/Cargo.toml
@@ -15,7 +15,6 @@ multipart = ["reqwest/multipart"]
 json = ["reqwest/json"]
 charset = ["reqwest/charset"]
 http2 = ["reqwest/http2"]
-rustls-tls = ["reqwest/rustls-tls"]
 
 [dependencies]
 anyhow = "1.0.0"

--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -11,7 +11,6 @@ categories = ["web-programming::http-client"]
 
 [features]
 default = ["tracing"]
-log = ["dep:log"]
 tracing = ["dep:tracing"]
 
 [dependencies]
@@ -20,7 +19,6 @@ reqwest-middleware = { version = "0.3.0", path = "../reqwest-middleware" }
 anyhow = "1.0.0"
 async-trait = "0.1.51"
 futures = "0.3.0"
-log = { version = "0.4.22", optional = true }
 http = "1.0"
 reqwest = { version = "0.12.0", default-features = false }
 retry-policies = "0.4"

--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -9,20 +9,26 @@ license = "MIT OR Apache-2.0"
 keywords = ["reqwest", "http", "middleware", "retry"]
 categories = ["web-programming::http-client"]
 
+[features]
+default = ["tracing"]
+log = ["dep:log"]
+tracing = ["dep:tracing"]
+
 [dependencies]
 reqwest-middleware = { version = "0.3.0", path = "../reqwest-middleware" }
 
 anyhow = "1.0.0"
 async-trait = "0.1.51"
 futures = "0.3.0"
+log = { version = "0.4.22", optional = true }
 http = "1.0"
 reqwest = { version = "0.12.0", default-features = false }
 retry-policies = "0.4"
-tracing = "0.1.26"
+tracing = { version = "0.1.26", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 hyper = "1.0"
-tokio = { version = "1.6.0", features = ["time"] }
+tokio = { version = "1.6.0", default-features = false, features = ["time"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 parking_lot = { version = "0.11.2", features = ["wasm-bindgen"] } # work around https://github.com/tomaka/wasm-timer/issues/14

--- a/reqwest-retry/src/middleware.rs
+++ b/reqwest-retry/src/middleware.rs
@@ -11,8 +11,13 @@ use retry_policies::RetryPolicy;
 
 #[cfg(feature = "tracing")]
 type LogLevel = ::tracing::Level;
+#[cfg(feature = "tracing")]
+use ::tracing as LogTracing;
+
 #[cfg(all(feature = "log", not(feature = "tracing")))]
 type LogLevel = ::log::Level;
+#[cfg(all(feature = "log", not(feature = "tracing")))]
+use ::log as LogTracing;
 
 #[doc(hidden)]
 // We need this macro because tracing expects the level to be const:
@@ -20,11 +25,11 @@ type LogLevel = ::log::Level;
 macro_rules! log_retry {
     ($level:expr, $($args:tt)*) => {{
         match $level {
-            LogLevel::TRACE => ::tracing::trace!($($args)*),
-            LogLevel::DEBUG => ::tracing::debug!($($args)*),
-            LogLevel::INFO => ::tracing::info!($($args)*),
-            LogLevel::WARN => ::tracing::warn!($($args)*),
-            LogLevel::ERROR => ::tracing::error!($($args)*),
+            LogLevel::TRACE => LogTracing::trace!($($args)*),
+            LogLevel::DEBUG => LogTracing::debug!($($args)*),
+            LogLevel::INFO => LogTracing::info!($($args)*),
+            LogLevel::WARN => LogTracing::warn!($($args)*),
+            LogLevel::ERROR => LogTracing::error!($($args)*),
         }
     }};
 }

--- a/reqwest-retry/src/middleware.rs
+++ b/reqwest-retry/src/middleware.rs
@@ -71,7 +71,7 @@ pub struct RetryTransientMiddleware<
     retry_policy: T,
     retryable_strategy: R,
     #[cfg(feature = "tracing")]
-    retry_log_level: ::tracing::Level,
+    retry_log_level: tracing::Level,
 }
 
 impl<T: RetryPolicy + Send + Sync> RetryTransientMiddleware<T, DefaultRetryableStrategy> {
@@ -83,7 +83,7 @@ impl<T: RetryPolicy + Send + Sync> RetryTransientMiddleware<T, DefaultRetryableS
     /// Set the log [level][tracing::Level] for retry events.
     /// The default is [`WARN`][tracing::Level::WARN].
     #[cfg(feature = "tracing")]
-    pub fn with_retry_log_level(mut self, level: ::tracing::Level) -> Self {
+    pub fn with_retry_log_level(mut self, level: tracing::Level) -> Self {
         self.retry_log_level = level;
         self
     }
@@ -100,7 +100,7 @@ where
             retry_policy,
             retryable_strategy,
             #[cfg(feature = "tracing")]
-            retry_log_level: ::tracing::Level::WARN,
+            retry_log_level: tracing::Level::WARN,
         }
     }
 }

--- a/reqwest-retry/src/middleware.rs
+++ b/reqwest-retry/src/middleware.rs
@@ -9,17 +9,22 @@ use reqwest::{Request, Response};
 use reqwest_middleware::{Error, Middleware, Next, Result};
 use retry_policies::RetryPolicy;
 
+#[cfg(feature = "tracing")]
+type LogLevel = ::tracing::Level;
+#[cfg(all(feature = "log", not(feature = "tracing")))]
+type LogLevel = ::log::Level;
+
 #[doc(hidden)]
 // We need this macro because tracing expects the level to be const:
 // https://github.com/tokio-rs/tracing/issues/2730
 macro_rules! log_retry {
     ($level:expr, $($args:tt)*) => {{
         match $level {
-            ::tracing::Level::TRACE => ::tracing::trace!($($args)*),
-            ::tracing::Level::DEBUG => ::tracing::debug!($($args)*),
-            ::tracing::Level::INFO => ::tracing::info!($($args)*),
-            ::tracing::Level::WARN => ::tracing::warn!($($args)*),
-            ::tracing::Level::ERROR => ::tracing::error!($($args)*),
+            LogLevel::TRACE => ::tracing::trace!($($args)*),
+            LogLevel::DEBUG => ::tracing::debug!($($args)*),
+            LogLevel::INFO => ::tracing::info!($($args)*),
+            LogLevel::WARN => ::tracing::warn!($($args)*),
+            LogLevel::ERROR => ::tracing::error!($($args)*),
         }
     }};
 }
@@ -69,7 +74,8 @@ pub struct RetryTransientMiddleware<
 > {
     retry_policy: T,
     retryable_strategy: R,
-    retry_log_level: tracing::Level,
+    #[cfg(any(feature = "log", feature = "tracing"))]
+    retry_log_level: LogLevel,
 }
 
 impl<T: RetryPolicy + Send + Sync> RetryTransientMiddleware<T, DefaultRetryableStrategy> {
@@ -80,7 +86,8 @@ impl<T: RetryPolicy + Send + Sync> RetryTransientMiddleware<T, DefaultRetryableS
 
     /// Set the log [level][tracing::Level] for retry events.
     /// The default is [`WARN`][tracing::Level::WARN].
-    pub fn with_retry_log_level(mut self, level: tracing::Level) -> Self {
+    #[cfg(any(feature = "log", feature = "tracing"))]
+    pub fn with_retry_log_level(mut self, level: LogLevel) -> Self {
         self.retry_log_level = level;
         self
     }
@@ -96,7 +103,7 @@ where
         Self {
             retry_policy,
             retryable_strategy,
-            retry_log_level: tracing::Level::WARN,
+            retry_log_level: LogLevel::WARN,
         }
     }
 }

--- a/reqwest-retry/src/middleware.rs
+++ b/reqwest-retry/src/middleware.rs
@@ -22,6 +22,7 @@ use ::log as LogTracing;
 #[doc(hidden)]
 // We need this macro because tracing expects the level to be const:
 // https://github.com/tokio-rs/tracing/issues/2730
+#[cfg(feature = "tracing")]
 macro_rules! log_retry {
     ($level:expr, $($args:tt)*) => {{
         match $level {
@@ -31,6 +32,13 @@ macro_rules! log_retry {
             LogLevel::WARN => LogTracing::warn!($($args)*),
             LogLevel::ERROR => LogTracing::error!($($args)*),
         }
+    }};
+}
+
+#[cfg(all(feature = "log", not(feature = "tracing")))]
+macro_rules! log_retry {
+    ($level:expr, $($args:tt)*) => {{
+        LogTracing::log!($level, $($args)*)
     }};
 }
 
@@ -108,7 +116,10 @@ where
         Self {
             retry_policy,
             retryable_strategy,
+            #[cfg(feature = "tracing")]
             retry_log_level: LogLevel::WARN,
+            #[cfg(all(feature = "log", not(feature = "tracing")))]
+            retry_log_level: LogLevel::Warn,
         }
     }
 }
@@ -175,6 +186,7 @@ where
                             .duration_since(SystemTime::now())
                             .unwrap_or_else(|_| Duration::default());
                         // Sleep the requested amount before we try again.
+                        #[cfg(any(feature = "log", feature = "tracing"))]
                         log_retry!(
                             self.retry_log_level,
                             "Retry attempt #{}. Sleeping {:?} before the next attempt",


### PR DESCRIPTION
This pull request is trying to reduce dependencies by:
* removing not used deps or disabling default features
* making `tracing` dependency optional and using `log` instead

I hope I did cfg correctly as I'm doing it first time