### PR TITLE
fix(test): enable `rustls-tls` for tests

### DIFF
--- a/reqwest-middleware/Cargo.toml
+++ b/reqwest-middleware/Cargo.toml
@@ -27,6 +27,7 @@ thiserror = "1.0.21"
 tower-service = "0.3.0"
 
 [dev-dependencies]
+reqwest = { version = "0.12.0", features = ["rustls-tls"] }
 reqwest-retry = { path = "../reqwest-retry" }
 reqwest-tracing = { path = "../reqwest-tracing" }
 tokio = { version = "1.0.0", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
This is helpful for [this test](https://github.com/TrueLayer/reqwest-middleware/blob/c90089ebd4cecf7cfb7d84d6664a993983682ce1/reqwest-middleware/src/lib.rs#L8).

This enables tests to pass when running `cargo test --no-default-features`.
