### PR TITLE
fix(lint): `clippy::doc_lazy_continuation`

### DIFF
--- a/reqwest-retry/src/middleware.rs
+++ b/reqwest-retry/src/middleware.rs
@@ -59,10 +59,10 @@ macro_rules! log_retry {
 ///
 /// Some workaround suggestions:
 /// * If you can fit the data in memory, you can instead build static request bodies e.g. with
-/// `Body`'s `From<String>` or `From<Bytes>` implementations.
+///   `Body`'s `From<String>` or `From<Bytes>` implementations.
 /// * You can wrap this middleware in a custom one which skips retries for streaming requests.
 /// * You can write a custom retry middleware that builds new streaming requests from the data
-/// source directly, avoiding the issue of streaming requests not being clonable.
+///   source directly, avoiding the issue of streaming requests not being clonable.
 pub struct RetryTransientMiddleware<
     T: RetryPolicy + Send + Sync + 'static,
     R: RetryableStrategy + Send + Sync + 'static = DefaultRetryableStrategy,


### PR DESCRIPTION
```
error: doc list item missing indentation
Error:   --> reqwest-retry/src/middleware.rs:62:4
   |
62 | /// `Body`'s `From<String>` or `From<Bytes>` implementations.
   |    ^
   |
   = help: if this is supposed to be its own paragraph, add a blank line
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_lazy_continuation
   = note: `-D clippy::doc-lazy-continuation` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::doc_lazy_continuation)]`
help: indent this line
   |
62 | ///   `Body`'s `From<String>` or `From<Bytes>` implementations.
   |     ++

error: doc list item missing indentation
Error:   --> reqwest-retry/src/middleware.rs:65:4
   |
65 | /// source directly, avoiding the issue of streaming requests not being clonable.
   |    ^
   |
   = help: if this is supposed to be its own paragraph, add a blank line
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_lazy_continuation
help: indent this line
   |
65 | ///   source directly, avoiding the issue of streaming requests not being clonable.
   |     ++

error: could not compile `reqwest-retry` (lib) due to 2 previous errors
```
