### PR TITLE
ci: use `cargo hack` feature powerset in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,8 @@ name: CI # Continuous Integration
 jobs:
 
   test:
-    name: Test Suite
+    name: Run test suite
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        otel_version:
-          - opentelemetry_0_20
-          - opentelemetry_0_21
-          - opentelemetry_0_22
-          - opentelemetry_0_23
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -28,8 +21,25 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --all-targets --features "reqwest-tracing/deprecated_attributes, ${{ matrix.otel_version }}"
+          args: --workspace --all-targets --all-features
 
+  test-features:
+    name: Run test suite with every feature combination
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+      - name: test
+        run: cargo hack test --feature-powerset
+  
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest
@@ -50,15 +60,8 @@ jobs:
           args: --all -- --check
 
   clippy:
-    name: Clippy
+    name: Run clippy
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        otel_version:
-          - opentelemetry_0_20
-          - opentelemetry_0_21
-          - opentelemetry_0_22
-          - opentelemetry_0_23
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -73,7 +76,26 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-targets --features "reqwest-tracing/deprecated_attributes, ${{ matrix.otel_version }}" --workspace -- -D warnings
+          args: --all-targets --all-features --workspace -- -D warnings
+
+
+  clippy-features:
+    name: Run clippy for every feature combination
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+          components: clippy
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+      - name: test
+        run: cargo hack clippy --feature-powerset
 
   typos:
     name: Spell Check with Typos
@@ -87,13 +109,6 @@ jobs:
   docs:
     name: Docs
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        otel_version:
-          - opentelemetry_0_20
-          - opentelemetry_0_21
-          - opentelemetry_0_22
-          - opentelemetry_0_23
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -109,7 +124,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: --no-deps --document-private-items --features "reqwest-tracing/deprecated_attributes, ${{ matrix.otel_version }}" --workspace
+          args: --no-deps --document-private-items --all-features --workspace
 
   publish-check:
     name: Publish dry run


### PR DESCRIPTION
waiting on #175 & #176 to fix issues with the build

Recently a [change was introduced that did not compile](https://github.com/TrueLayer/reqwest-middleware/pull/167/files/4a2b3f335e9ea2f080f0d13ee782b830607b1f60#r1689595502) #167.

This was not caught by our CI becuase the feature was not enabled when building in CI.

This change ensures that every possible feature combination is attempted when running tests and clippy in CI. This adds up to 50 attempts for all of our features accross the three crates in this repo. This doesn't take too long since they share build cache.
