### PR TITLE
Added `Default` derive to allow for same functionality as base type

### DIFF
--- a/reqwest-middleware/src/client.rs
+++ b/reqwest-middleware/src/client.rs
@@ -93,7 +93,7 @@ impl ClientBuilder {
 
 /// `ClientWithMiddleware` is a wrapper around [`reqwest::Client`] which runs middleware on every
 /// request.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct ClientWithMiddleware {
     inner: reqwest::Client,
     middleware_stack: Box<[Arc<dyn Middleware>]>,


### PR DESCRIPTION
<!-- Please explain the changes you made -->

Adding `Default` derive macro to the `ClientWithMiddleware` type in order to have the same functionnality as base `reqwest::Client`

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/reqwest-middleware/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CHANGELOG.md
-->
