### PR TITLE
Use new matchit syntax in documentation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 <!--
 Please, make sure:
 - you have read the contributing guidelines:
-  https://github.com/TrueLayer/reqwest-middleware/blob/main/docs/CONTRIBUTING.md
+  https://github.com/TrueLayer/reqwest-middleware/blob/main/CONTRIBUTING.md
 - you have formatted the code using rustfmt:
   https://github.com/rust-lang/rustfmt
 - you have checked that all tests pass, by running `cargo test --all`

--- a/reqwest-tracing/src/reqwest_otel_span_builder.rs
+++ b/reqwest-tracing/src/reqwest_otel_span_builder.rs
@@ -242,7 +242,7 @@ pub struct OtelName(pub Cow<'static, str>);
 /// let reqwest_client = reqwest::Client::builder().build()?;
 /// let client = ClientBuilder::new(reqwest_client)
 ///    // Inserts the extension before the request is started
-///    .with_init(Extension(OtelPathNames::known_paths(["/payment/:paymentId"])?))
+///    .with_init(Extension(OtelPathNames::known_paths(["/payment/{paymentId}"])?))
 ///    // Makes use of that extension to specify the otel name
 ///    .with(TracingMiddleware::default())
 ///    .build();
@@ -251,7 +251,7 @@ pub struct OtelName(pub Cow<'static, str>);
 ///
 /// // Or specify it on the individual request (will take priority)
 /// let resp = client.post("https://api.truelayer.com/payment/id-123/authorization-flow")
-///     .with_extension(OtelPathNames::known_paths(["/payment/:paymentId/authorization-flow"])?)
+///     .with_extension(OtelPathNames::known_paths(["/payment/{paymentId}/authorization-flow"])?)
 ///    .send()
 ///    .await?;
 /// # Ok(())
@@ -273,8 +273,8 @@ impl OtelPathNames {
     /// OtelPathNames::known_paths([
     ///     "/",
     ///     "/payment",
-    ///     "/payment/:paymentId",
-    ///     "/payment/:paymentId/*action",
+    ///     "/payment/{paymentId}",
+    ///     "/payment/{paymentId}/*action",
     /// ]).unwrap();
     /// ```
     pub fn known_paths<Paths, Path>(paths: Paths) -> anyhow::Result<Self>


### PR DESCRIPTION
There were still some examples of the pre-v0.8 matchit syntax in the documentation. This PR updates them to the new syntax (and fixes a broken link in the GitHub pull request template).

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/reqwest-middleware/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CHANGELOG.md
-->
