### PR TITLE
fix: v0.12.6 reqwest compatibility

### DIFF
--- a/reqwest-middleware/src/client.rs
+++ b/reqwest-middleware/src/client.rs
@@ -281,7 +281,8 @@ mod service {
         type Future = Pending;
 
         fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
-            self.inner.poll_ready(cx).map_err(crate::Error::Reqwest)
+            <reqwest::Client as tower_service::Service<Request>>::poll_ready(&mut self.inner, cx)
+                .map_err(crate::Error::Reqwest)
         }
 
         fn call(&mut self, req: Request) -> Self::Future {
@@ -303,7 +304,11 @@ mod service {
         type Future = Pending;
 
         fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
-            (&self.inner).poll_ready(cx).map_err(crate::Error::Reqwest)
+            <&reqwest::Client as tower_service::Service<Request>>::poll_ready(
+                &mut (&self.inner),
+                cx,
+            )
+            .map_err(crate::Error::Reqwest)
         }
 
         fn call(&mut self, req: Request) -> Self::Future {


### PR DESCRIPTION
closes #182 

In v0.12.6 reqwest added an additional `tower::Service` impl on `Client`. These changes add type annotations to disambiguate the intended impl.

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/reqwest-middleware/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CHANGELOG.md
-->
