### PR TITLE
fix: restore adding http.url as an attribute when deprecated_attributes feature is enabled

### DIFF
--- a/reqwest-tracing/CHANGELOG.md
+++ b/reqwest-tracing/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Restore adding `http.url` attribute when using `SpanBackendWithUrl` middleware with the `deprecated_attributes` feature enabled
+
 ## [0.5.2] - 2024-07-15
 
 ### Added

--- a/reqwest-tracing/src/reqwest_otel_span_builder.rs
+++ b/reqwest-tracing/src/reqwest_otel_span_builder.rs
@@ -165,7 +165,13 @@ pub struct SpanBackendWithUrl;
 impl ReqwestOtelSpanBackend for SpanBackendWithUrl {
     fn on_request_start(req: &Request, ext: &mut Extensions) -> Span {
         let name = default_span_name(req, ext);
-        reqwest_otel_span!(name = name, req, url.full = %remove_credentials(req.url()))
+        let url = remove_credentials(req.url());
+        let span = reqwest_otel_span!(name = name, req, url.full = %url);
+        #[cfg(feature = "deprecated_attributes")]
+        {
+            span.record(HTTP_URL, url.to_string());
+        }
+        span
     }
 
     fn on_request_end(span: &Span, outcome: &Result<Response>, _: &mut Extensions) {


### PR DESCRIPTION
<!-- Please explain the changes you made -->
 - The `SpanBackendWithUrl` middleware used to add the `http.url` attribute which was migrated to the `url.full` attribute as part of https://github.com/TrueLayer/reqwest-middleware/pull/141 but was not restored along with the other deprecated attributes when the `deprecated_attributes` feature was added so this change is to add it back in if that feature is enabled

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/reqwest-middleware/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CHANGELOG.md
-->
