### PR TITLE
feat: Support OTel 0.25 & 0.26

### DIFF
--- a/reqwest-tracing/CHANGELOG.md
+++ b/reqwest-tracing/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added support for OpenTelemetry `0.25` ([#188](https://github.com/TrueLayer/reqwest-middleware/pull/188))
+
 ### Changed
 - Restore adding `http.url` attribute when using `SpanBackendWithUrl` middleware with the `deprecated_attributes` feature enabled
 

--- a/reqwest-tracing/CHANGELOG.md
+++ b/reqwest-tracing/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added support for OpenTelemetry `0.25` ([#188](https://github.com/TrueLayer/reqwest-middleware/pull/188))
+- Added support for OpenTelemetry `0.26` ([#188](https://github.com/TrueLayer/reqwest-middleware/pull/188))
 
 ### Changed
 - Restore adding `http.url` attribute when using `SpanBackendWithUrl` middleware with the `deprecated_attributes` feature enabled

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -16,6 +16,7 @@ opentelemetry_0_22 = ["opentelemetry_0_22_pkg", "tracing-opentelemetry_0_23_pkg"
 opentelemetry_0_23 = ["opentelemetry_0_23_pkg", "tracing-opentelemetry_0_24_pkg"]
 opentelemetry_0_24 = ["opentelemetry_0_24_pkg", "tracing-opentelemetry_0_25_pkg"]
 opentelemetry_0_25 = ["opentelemetry_0_25_pkg", "tracing-opentelemetry_0_26_pkg"]
+opentelemetry_0_26 = ["opentelemetry_0_26_pkg", "tracing-opentelemetry_0_27_pkg"]
 # This feature ensures that both the old (deprecated) and new attributes are published simultaneously.
 # By doing so, we maintain backward compatibility, allowing existing code that relies on the old attributes
 # to continue functioning while encouraging the transition to the new attributes.
@@ -37,12 +38,14 @@ opentelemetry_0_22_pkg = { package = "opentelemetry", version = "0.22.0", option
 opentelemetry_0_23_pkg = { package = "opentelemetry", version = "0.23.0", optional = true }
 opentelemetry_0_24_pkg = { package = "opentelemetry", version = "0.24.0", optional = true }
 opentelemetry_0_25_pkg = { package = "opentelemetry", version = "0.25.0", optional = true }
+opentelemetry_0_26_pkg = { package = "opentelemetry", version = "0.26.0", optional = true }
 tracing-opentelemetry_0_21_pkg = { package = "tracing-opentelemetry", version = "0.21.0", optional = true }
 tracing-opentelemetry_0_22_pkg = { package = "tracing-opentelemetry", version = "0.22.0", optional = true }
 tracing-opentelemetry_0_23_pkg = { package = "tracing-opentelemetry", version = "0.23.0", optional = true }
 tracing-opentelemetry_0_24_pkg = { package = "tracing-opentelemetry", version = "0.24.0", optional = true }
 tracing-opentelemetry_0_25_pkg = { package = "tracing-opentelemetry", version = "0.25.0", optional = true }
 tracing-opentelemetry_0_26_pkg = { package = "tracing-opentelemetry", version = "0.26.0", optional = true }
+tracing-opentelemetry_0_27_pkg = { package = "tracing-opentelemetry", version = "0.27.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.0", features = ["js"] }
@@ -58,6 +61,7 @@ opentelemetry_sdk_0_22 = { package = "opentelemetry_sdk", version = "0.22.0", fe
 opentelemetry_sdk_0_23 = { package = "opentelemetry_sdk", version = "0.23.0", features = ["trace"] }
 opentelemetry_sdk_0_24 = { package = "opentelemetry_sdk", version = "0.24.1", features = ["trace"] }
 opentelemetry_sdk_0_25 = { package = "opentelemetry_sdk", version = "0.25.0", features = ["trace"] }
+opentelemetry_sdk_0_26 = { package = "opentelemetry_sdk", version = "0.26.0", features = ["trace"] }
 opentelemetry_stdout_0_1 = { package = "opentelemetry-stdout", version = "0.1.0", features = ["trace"] }
 opentelemetry_stdout_0_2 = { package = "opentelemetry-stdout", version = "0.2.0", features = ["trace"] }
 opentelemetry_stdout_0_3 = { package = "opentelemetry-stdout", version = "0.3.0", features = ["trace"] }

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -15,6 +15,7 @@ opentelemetry_0_21 = ["opentelemetry_0_21_pkg", "tracing-opentelemetry_0_22_pkg"
 opentelemetry_0_22 = ["opentelemetry_0_22_pkg", "tracing-opentelemetry_0_23_pkg"]
 opentelemetry_0_23 = ["opentelemetry_0_23_pkg", "tracing-opentelemetry_0_24_pkg"]
 opentelemetry_0_24 = ["opentelemetry_0_24_pkg", "tracing-opentelemetry_0_25_pkg"]
+opentelemetry_0_25 = ["opentelemetry_0_25_pkg", "tracing-opentelemetry_0_26_pkg"]
 # This feature ensures that both the old (deprecated) and new attributes are published simultaneously.
 # By doing so, we maintain backward compatibility, allowing existing code that relies on the old attributes
 # to continue functioning while encouraging the transition to the new attributes.
@@ -35,11 +36,13 @@ opentelemetry_0_21_pkg = { package = "opentelemetry", version = "0.21.0", option
 opentelemetry_0_22_pkg = { package = "opentelemetry", version = "0.22.0", optional = true }
 opentelemetry_0_23_pkg = { package = "opentelemetry", version = "0.23.0", optional = true }
 opentelemetry_0_24_pkg = { package = "opentelemetry", version = "0.24.0", optional = true }
+opentelemetry_0_25_pkg = { package = "opentelemetry", version = "0.25.0", optional = true }
 tracing-opentelemetry_0_21_pkg = { package = "tracing-opentelemetry", version = "0.21.0", optional = true }
 tracing-opentelemetry_0_22_pkg = { package = "tracing-opentelemetry", version = "0.22.0", optional = true }
 tracing-opentelemetry_0_23_pkg = { package = "tracing-opentelemetry", version = "0.23.0", optional = true }
 tracing-opentelemetry_0_24_pkg = { package = "tracing-opentelemetry", version = "0.24.0", optional = true }
 tracing-opentelemetry_0_25_pkg = { package = "tracing-opentelemetry", version = "0.25.0", optional = true }
+tracing-opentelemetry_0_26_pkg = { package = "tracing-opentelemetry", version = "0.26.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.0", features = ["js"] }
@@ -54,9 +57,9 @@ opentelemetry_sdk_0_21 = { package = "opentelemetry_sdk", version = "0.21.0", fe
 opentelemetry_sdk_0_22 = { package = "opentelemetry_sdk", version = "0.22.0", features = ["trace"] }
 opentelemetry_sdk_0_23 = { package = "opentelemetry_sdk", version = "0.23.0", features = ["trace"] }
 opentelemetry_sdk_0_24 = { package = "opentelemetry_sdk", version = "0.24.1", features = ["trace"] }
+opentelemetry_sdk_0_25 = { package = "opentelemetry_sdk", version = "0.25.0", features = ["trace"] }
 opentelemetry_stdout_0_1 = { package = "opentelemetry-stdout", version = "0.1.0", features = ["trace"] }
 opentelemetry_stdout_0_2 = { package = "opentelemetry-stdout", version = "0.2.0", features = ["trace"] }
 opentelemetry_stdout_0_3 = { package = "opentelemetry-stdout", version = "0.3.0", features = ["trace"] }
 opentelemetry_stdout_0_4 = { package = "opentelemetry-stdout", version = "0.4.0", features = ["trace"] }
 opentelemetry_stdout_0_5 = { package = "opentelemetry-stdout", version = "0.5.0", features = ["trace"] }
-

--- a/reqwest-tracing/src/lib.rs
+++ b/reqwest-tracing/src/lib.rs
@@ -89,6 +89,7 @@ mod middleware;
     feature = "opentelemetry_0_22",
     feature = "opentelemetry_0_23",
     feature = "opentelemetry_0_24",
+    feature = "opentelemetry_0_25",
 ))]
 mod otel;
 mod reqwest_otel_span_builder;

--- a/reqwest-tracing/src/lib.rs
+++ b/reqwest-tracing/src/lib.rs
@@ -90,6 +90,7 @@ mod middleware;
     feature = "opentelemetry_0_23",
     feature = "opentelemetry_0_24",
     feature = "opentelemetry_0_25",
+    feature = "opentelemetry_0_26",
 ))]
 mod otel;
 mod reqwest_otel_span_builder;

--- a/reqwest-tracing/src/middleware.rs
+++ b/reqwest-tracing/src/middleware.rs
@@ -52,6 +52,7 @@ where
                 feature = "opentelemetry_0_23",
                 feature = "opentelemetry_0_24",
                 feature = "opentelemetry_0_25",
+                feature = "opentelemetry_0_26",
             ))]
             let req = if extensions.get::<crate::DisableOtelPropagation>().is_none() {
                 // Adds tracing headers to the given request to propagate the OpenTelemetry context to downstream revivers of the request.

--- a/reqwest-tracing/src/middleware.rs
+++ b/reqwest-tracing/src/middleware.rs
@@ -51,6 +51,7 @@ where
                 feature = "opentelemetry_0_22",
                 feature = "opentelemetry_0_23",
                 feature = "opentelemetry_0_24",
+                feature = "opentelemetry_0_25",
             ))]
             let req = if extensions.get::<crate::DisableOtelPropagation>().is_none() {
                 // Adds tracing headers to the given request to propagate the OpenTelemetry context to downstream revivers of the request.

--- a/reqwest-tracing/src/otel.rs
+++ b/reqwest-tracing/src/otel.rs
@@ -47,6 +47,13 @@ pub fn inject_opentelemetry_context_into_request(mut request: Request) -> Reques
         injector.inject_context(&context, &mut RequestCarrier::new(&mut request))
     });
 
+    #[cfg(feature = "opentelemetry_0_26")]
+    opentelemetry_0_26_pkg::global::get_text_map_propagator(|injector| {
+        use tracing_opentelemetry_0_27_pkg::OpenTelemetrySpanExt;
+        let context = Span::current().context();
+        injector.inject_context(&context, &mut RequestCarrier::new(&mut request))
+    });
+
     request
 }
 
@@ -111,6 +118,13 @@ impl<'a> opentelemetry_0_24_pkg::propagation::Injector for RequestCarrier<'a> {
 
 #[cfg(feature = "opentelemetry_0_25")]
 impl<'a> opentelemetry_0_25_pkg::propagation::Injector for RequestCarrier<'a> {
+    fn set(&mut self, key: &str, value: String) {
+        self.set_inner(key, value)
+    }
+}
+
+#[cfg(feature = "opentelemetry_0_26")]
+impl<'a> opentelemetry_0_26_pkg::propagation::Injector for RequestCarrier<'a> {
     fn set(&mut self, key: &str, value: String) {
         self.set_inner(key, value)
     }
@@ -264,6 +278,22 @@ mod test {
                 );
 
                 let telemetry = tracing_opentelemetry_0_26_pkg::layer().with_tracer(tracer);
+                subscriber.with(telemetry)
+            };
+
+            #[cfg(feature = "opentelemetry_0_26")]
+            let subscriber = {
+                use opentelemetry_0_26_pkg::trace::TracerProvider;
+
+                let provider = opentelemetry_sdk_0_26::trace::TracerProvider::builder().build();
+
+                let tracer = provider.tracer_builder("reqwest").build();
+                let _ = opentelemetry_0_26_pkg::global::set_tracer_provider(provider);
+                opentelemetry_0_26_pkg::global::set_text_map_propagator(
+                    opentelemetry_sdk_0_26::propagation::TraceContextPropagator::new(),
+                );
+
+                let telemetry = tracing_opentelemetry_0_27_pkg::layer().with_tracer(tracer);
                 subscriber.with(telemetry)
             };
 


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CHANGELOG.md
-->

Note that https://github.com/open-telemetry/opentelemetry-rust/pull/2040 removed custom `writer` support from `opentelemetry-stdout`, so I didn't add that to the tests. Not sure what its purpose is since it only uses `std::io::sink()` anyways?