### PR TITLE
Release new versions

### DIFF
--- a/reqwest-middleware/CHANGELOG.md
+++ b/reqwest-middleware/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+## [0.4.0] - 2024-11-08
+
+### Breaking Changes
 - `request_middleware::Error` is now a transparent error enum and doesn't add its own context anymore.
 
 ## [0.3.3] - 2024-07-08

--- a/reqwest-middleware/Cargo.toml
+++ b/reqwest-middleware/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-middleware"
-version = "0.3.3"
+version = "0.4.0"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Wrapper around reqwest to allow for client middleware chains."

--- a/reqwest-retry/CHANGELOG.md
+++ b/reqwest-retry/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.0]
+## [Unreleased]
+
+## [0.7.0] - 2024-11-08
+
+### Breaking changes
+- Errors are now reported as `RetryError` that adds the number of retries to the error chain if there were any. This changes the returned error types.
+
+### Added
+- Added support reqwest-middleware `0.4` next to `0.3`
 
 ## [0.6.1] - 2024-08-08
 
@@ -18,7 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Upgraded `retry-policies` to `0.4.0`.
-- **Breaking Change** Errors are now reported as `RetryError` that adds the number of retries to the error chain if there were any. This changes the returned error types.
 
 ## [0.5.0] - 2024-04-10
 

--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-retry"
-version = "0.7.1"
+version = "0.7.0"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Retry middleware for reqwest."
@@ -14,7 +14,7 @@ default = ["tracing"]
 tracing = ["dep:tracing"]
 
 [dependencies]
-reqwest-middleware = { version = "0.3.0", path = "../reqwest-middleware" }
+reqwest-middleware = { version = ">0.3.0, <0.5.0", path = "../reqwest-middleware" }
 
 anyhow = "1.0.0"
 async-trait = "0.1.51"

--- a/reqwest-tracing/CHANGELOG.md
+++ b/reqwest-tracing/CHANGELOG.md
@@ -7,14 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.4] - 2024-11-08
+
 ### Added
 - Added support for OpenTelemetry `0.25` ([#188](https://github.com/TrueLayer/reqwest-middleware/pull/188))
 - Added support for OpenTelemetry `0.26` ([#188](https://github.com/TrueLayer/reqwest-middleware/pull/188))
+- Added support reqwest-middleware `0.4` next to `0.3`
 
 ### Changed
 - Restore adding `http.url` attribute when using `SpanBackendWithUrl` middleware with the `deprecated_attributes` feature enabled
 
-## [0.5.2] - 2024-07-15
+## [0.5.3] - 2024-07-15
 
 ### Added
 - Added support for OpenTelemetry `0.24` ([#171](https://github.com/TrueLayer/reqwest-middleware/pull/171))

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-tracing"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Opentracing middleware for reqwest."
@@ -23,7 +23,7 @@ opentelemetry_0_26 = ["opentelemetry_0_26_pkg", "tracing-opentelemetry_0_27_pkg"
 deprecated_attributes = []
 
 [dependencies]
-reqwest-middleware = { version = "0.3.0", path = "../reqwest-middleware" }
+reqwest-middleware = { version = ">0.3.0, <0.5.0", path = "../reqwest-middleware" }
 
 anyhow = "1.0.70"
 async-trait = "0.1.51"


### PR DESCRIPTION
Hi,

I'd like to ask for new releases for the middleware crates: reqwest-middleware 0.4.0, reqwest-retry 0.7.0 and reqwest-tracing 0.5.4.

In [uv](https://github.com/astral-sh/uv), we're currently using a git dependency for https://github.com/TrueLayer/reqwest-middleware/pull/159, and we'd like to move to a crates.io dependency (https://github.com/astral-sh/uv/issues/8932).

I've bump reqwest-middleware and reqwest-retry according to being breaking changes in the error type, while requiring reqwest-middleware `>0.3.0, <0.5.0` in reqwest-retry and reqwest-tracing for minimal downstream disruption. I hope i got all the version number and changelog changes right.