### PR TITLE
Update wasm-timer to wasmtimer

### DIFF
--- a/reqwest-middleware/CHANGELOG.md
+++ b/reqwest-middleware/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Updated `wasm-timer` to `wasmtimer`
+
 ## [0.4.0] - 2024-11-08
 
 ### Breaking Changes

--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -24,14 +24,14 @@ reqwest = { version = "0.12.0", default-features = false }
 retry-policies = "0.4"
 thiserror = "1.0.61"
 tracing = { version = "0.1.26", optional = true }
+wasmtimer = "0.4.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 hyper = "1.0"
 tokio = { version = "1.6.0", default-features = false, features = ["time"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-parking_lot = { version = "0.11.2", features = ["wasm-bindgen"] } # work around https://github.com/tomaka/wasm-timer/issues/14
-wasm-timer = "0.2.5"
+
 getrandom = { version = "0.2.0", features = ["js"] }
 
 [dev-dependencies]

--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -24,14 +24,13 @@ reqwest = { version = "0.12.0", default-features = false }
 retry-policies = "0.4"
 thiserror = "1.0.61"
 tracing = { version = "0.1.26", optional = true }
-wasmtimer = "0.4.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 hyper = "1.0"
 tokio = { version = "1.6.0", default-features = false, features = ["time"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-
+wasmtimer = "0.4.1"
 getrandom = { version = "0.2.0", features = ["js"] }
 
 [dev-dependencies]

--- a/reqwest-retry/src/middleware.rs
+++ b/reqwest-retry/src/middleware.rs
@@ -177,9 +177,7 @@ where
                     #[cfg(not(target_arch = "wasm32"))]
                     tokio::time::sleep(duration).await;
                     #[cfg(target_arch = "wasm32")]
-                    wasm_timer::Delay::new(duration)
-                        .await
-                        .expect("failed sleeping");
+                    wasmtimer::tokio::sleep(duration).await;
 
                     n_past_retries += 1;
                     continue;


### PR DESCRIPTION
<!-- Please explain the changes you made -->
Swaps over to wasmtimer, an updated library from wasm-timer which is not maintained.
Closes #199 
See here for fork: https://github.com/google/tarpc/pull/388
<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CHANGELOG.md
-->
