### PR TITLE
Release new version of reqwest-tracing

### DIFF
--- a/reqwest-tracing/CHANGELOG.md
+++ b/reqwest-tracing/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.5] - 2024-12-02
+
 ### Added
 - Added support for OpenTelemetry `0.27` ([#201](https://github.com/TrueLayer/reqwest-middleware/pull/201))
 

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-tracing"
-version = "0.5.4"
+version = "0.5.5"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Opentracing middleware for reqwest."


### PR DESCRIPTION
Hello! Could we do a new release of reqwest-tracing to get the already-added opentelemetry 0.27 support out onto the published crate?