### PR TITLE
Fix wasm32 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,18 @@ jobs:
         uses: taiki-e/install-action@cargo-hack
       - name: test
         run: cargo hack test --feature-powerset -p reqwest-middleware
+  check-wasm32-reqwest-middleware:
+    name: Run `cargo check` for `reqwest-middleware` on `wasm32-unknown-unknown`
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target wasm32-unknown-unknown -p reqwest-middleware --all-features
   test-features-retry:
     name: Run test suite for `reqwest-retry` with every feature combination
     runs-on: ubuntu-latest

--- a/reqwest-middleware/CHANGELOG.md
+++ b/reqwest-middleware/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fixed wasm32 by disabling incompatible parts. On that target, `ClientWithMiddleware` is no longer
+  a Tower service and has no `ClientWithMiddleware::timeout` function.
 
 ## [0.4.0] - 2024-11-08
 

--- a/reqwest-middleware/src/client.rs
+++ b/reqwest-middleware/src/client.rs
@@ -247,6 +247,7 @@ impl fmt::Debug for ClientWithMiddleware {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 mod service {
     use std::{
         future::Future,
@@ -422,6 +423,7 @@ impl RequestBuilder {
     /// The timeout is applied from when the request starts connecting until the
     /// response body has finished. It affects only this request and overrides
     /// the timeout configured using `ClientBuilder::timeout()`.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn timeout(self, timeout: std::time::Duration) -> Self {
         RequestBuilder {
             inner: self.inner.timeout(timeout),


### PR DESCRIPTION
It is a followup for https://github.com/TrueLayer/reqwest-middleware/pull/162, but with CI step for wasm32 added. It runs only for `reqwest-middleware`, as other packages too have issues, which I was unable to investigate at the moment.