### PR TITLE
Expose internal reqwest::Client as reference

### DIFF
--- a/reqwest-middleware/src/client.rs
+++ b/reqwest-middleware/src/client.rs
@@ -247,7 +247,7 @@ impl fmt::Debug for ClientWithMiddleware {
     }
 }
 
-// Implementing AsRef<Client> for ClientWithMiddleware. 
+// Implementing AsRef<Client> for ClientWithMiddleware.
 //
 // This allows to use ClientWithMiddleware as a reqwest::Client.
 impl AsRef<Client> for ClientWithMiddleware {

--- a/reqwest-middleware/src/client.rs
+++ b/reqwest-middleware/src/client.rs
@@ -247,6 +247,15 @@ impl fmt::Debug for ClientWithMiddleware {
     }
 }
 
+// Implementing AsRef<Client> for ClientWithMiddleware. 
+//
+// This allows to use ClientWithMiddleware as a reqwest::Client.
+impl AsRef<Client> for ClientWithMiddleware {
+    fn as_ref(&self) -> &Client {
+        &self.inner
+    }
+}
+
 mod service {
     use std::{
         future::Future,


### PR DESCRIPTION
This is an action taken to address #203. I was adding this library to some of our internal projects when I found myself in the same need and decided to contribute to the change.

This PR exposes the inner `reqwest::Client` as a reference.

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CHANGELOG.md
-->
