### PR TITLE
chore: fix clippy warnings

### DIFF
--- a/reqwest-retry/tests/all/helpers/simple_server.rs
+++ b/reqwest-retry/tests/all/helpers/simple_server.rs
@@ -25,7 +25,7 @@ struct Request<'a> {
     http_version: &'a str,
 }
 
-impl<'a> fmt::Display for Request<'a> {
+impl fmt::Display for Request<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} {} {}\r\n", self.method, self.uri, self.http_version)
     }

--- a/reqwest-tracing/src/otel.rs
+++ b/reqwest-tracing/src/otel.rs
@@ -80,7 +80,7 @@ impl<'a> RequestCarrier<'a> {
     }
 }
 
-impl<'a> RequestCarrier<'a> {
+impl RequestCarrier<'_> {
     fn set_inner(&mut self, key: &str, value: String) {
         let header_name = HeaderName::from_str(key).expect("Must be header name");
         let header_value = HeaderValue::from_str(&value).expect("Must be a header value");
@@ -89,56 +89,56 @@ impl<'a> RequestCarrier<'a> {
 }
 
 #[cfg(feature = "opentelemetry_0_20")]
-impl<'a> opentelemetry_0_20_pkg::propagation::Injector for RequestCarrier<'a> {
+impl opentelemetry_0_20_pkg::propagation::Injector for RequestCarrier<'_> {
     fn set(&mut self, key: &str, value: String) {
         self.set_inner(key, value)
     }
 }
 
 #[cfg(feature = "opentelemetry_0_21")]
-impl<'a> opentelemetry_0_21_pkg::propagation::Injector for RequestCarrier<'a> {
+impl opentelemetry_0_21_pkg::propagation::Injector for RequestCarrier<'_> {
     fn set(&mut self, key: &str, value: String) {
         self.set_inner(key, value)
     }
 }
 
 #[cfg(feature = "opentelemetry_0_22")]
-impl<'a> opentelemetry_0_22_pkg::propagation::Injector for RequestCarrier<'a> {
+impl opentelemetry_0_22_pkg::propagation::Injector for RequestCarrier<'_> {
     fn set(&mut self, key: &str, value: String) {
         self.set_inner(key, value)
     }
 }
 
 #[cfg(feature = "opentelemetry_0_23")]
-impl<'a> opentelemetry_0_23_pkg::propagation::Injector for RequestCarrier<'a> {
+impl opentelemetry_0_23_pkg::propagation::Injector for RequestCarrier<'_> {
     fn set(&mut self, key: &str, value: String) {
         self.set_inner(key, value)
     }
 }
 
 #[cfg(feature = "opentelemetry_0_24")]
-impl<'a> opentelemetry_0_24_pkg::propagation::Injector for RequestCarrier<'a> {
+impl opentelemetry_0_24_pkg::propagation::Injector for RequestCarrier<'_> {
     fn set(&mut self, key: &str, value: String) {
         self.set_inner(key, value)
     }
 }
 
 #[cfg(feature = "opentelemetry_0_25")]
-impl<'a> opentelemetry_0_25_pkg::propagation::Injector for RequestCarrier<'a> {
+impl opentelemetry_0_25_pkg::propagation::Injector for RequestCarrier<'_> {
     fn set(&mut self, key: &str, value: String) {
         self.set_inner(key, value)
     }
 }
 
 #[cfg(feature = "opentelemetry_0_26")]
-impl<'a> opentelemetry_0_26_pkg::propagation::Injector for RequestCarrier<'a> {
+impl opentelemetry_0_26_pkg::propagation::Injector for RequestCarrier<'_> {
     fn set(&mut self, key: &str, value: String) {
         self.set_inner(key, value)
     }
 }
 
 #[cfg(feature = "opentelemetry_0_27")]
-impl<'a> opentelemetry_0_27_pkg::propagation::Injector for RequestCarrier<'a> {
+impl opentelemetry_0_27_pkg::propagation::Injector for RequestCarrier<'_> {
     fn set(&mut self, key: &str, value: String) {
         self.set_inner(key, value)
     }


### PR DESCRIPTION
Noticed these failing in #215. Seems better to address warnings from new version of `clippy` separately.

I just ran `cargo clippy --all-targets --all-features --fix`

(it might be a good idea to turn on CI for all PRs, that way the feedback loop is a bit tighter 😅 mostly a coincidence I checked if the PR had gotten any feedback as there's no notification from GH when CI runs. but if CI ran when I opened the PR, I would have acted 2 days ago)