### PR TITLE
Fix build issues after upgrading reqwest from 0.12.0 to 0.12.14

### DIFF
--- a/reqwest-middleware/CHANGELOG.md
+++ b/reqwest-middleware/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2025-02-24
+
+### Breaking changes
+- Upgraded `reqwest` to `0.12.14`
+  * Removed  `fetch_mode_no_cors` function as it was deprecated in earlier versions and removed finally from reqwest 0.12.14
+
+### Changed
+- upgrade cargo dependencies to latest versions
+
 ## [0.4.1] - 2025-02-24
 
 - Fixed wasm32 by disabling incompatible parts. On that target, `ClientWithMiddleware` is no longer

--- a/reqwest-middleware/CHANGELOG.md
+++ b/reqwest-middleware/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.0] - 2025-02-24
+## [0.5.0] - 2025-03-13
 
 ### Breaking changes
 - Upgraded `reqwest` to `0.12.14`

--- a/reqwest-middleware/Cargo.toml
+++ b/reqwest-middleware/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-middleware"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Wrapper around reqwest to allow for client middleware chains."
@@ -18,17 +18,17 @@ http2 = ["reqwest/http2"]
 rustls-tls = ["reqwest/rustls-tls"]
 
 [dependencies]
-anyhow = "1.0.0"
-async-trait = "0.1.51"
-http = "1.0.0"
-reqwest = { version = "0.12.0", default-features = false }
-serde = "1.0.106"
-thiserror = "1.0.21"
-tower-service = "0.3.0"
+anyhow = "1.0.97"
+async-trait = "0.1.87"
+http = "1.3.1"
+reqwest = { version = "0.12.14", default-features = false }
+serde = "1.0.219"
+thiserror = "2.0.12"
+tower-service = "0.3.3"
 
 [dev-dependencies]
-reqwest = { version = "0.12.0", features = ["rustls-tls"] }
+reqwest = { version = "0.12.14", features = ["rustls-tls"] }
 reqwest-retry = { path = "../reqwest-retry" }
 reqwest-tracing = { path = "../reqwest-tracing" }
-tokio = { version = "1.0.0", features = ["macros", "rt-multi-thread"] }
-wiremock = "0.6.0"
+tokio = { version = "1.44.0", features = ["macros", "rt-multi-thread"] }
+wiremock = "0.6.3"

--- a/reqwest-middleware/src/client.rs
+++ b/reqwest-middleware/src/client.rs
@@ -518,22 +518,6 @@ impl RequestBuilder {
         }
     }
 
-    /// Disable CORS on fetching the request.
-    ///
-    /// # WASM
-    ///
-    /// This option is only effective with WebAssembly target.
-    ///
-    /// The [request mode][mdn] will be set to 'no-cors'.
-    ///
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/Request/mode
-    pub fn fetch_mode_no_cors(self) -> Self {
-        RequestBuilder {
-            inner: self.inner.fetch_mode_no_cors(),
-            ..self
-        }
-    }
-
     /// Build a `Request`, which can be inspected, modified and executed with
     /// `ClientWithMiddleware::execute()`.
     pub fn build(self) -> reqwest::Result<Request> {

--- a/reqwest-retry/CHANGELOG.md
+++ b/reqwest-retry/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2025-03-13
+
+### Changed
+- Update reqwest from 0.12.0 to 0.12.14
+- Upgrade cargo dependencies to latest versions
+
 ## [0.7.0] - 2024-11-08
 
 ### Breaking changes

--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-retry"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Retry middleware for reqwest."
@@ -14,27 +14,27 @@ default = ["tracing"]
 tracing = ["dep:tracing"]
 
 [dependencies]
-reqwest-middleware = { version = ">0.3.0, <0.5.0", path = "../reqwest-middleware" }
+reqwest-middleware = { version = ">0.3.0, <0.6.0", path = "../reqwest-middleware" }
 
-anyhow = "1.0.0"
-async-trait = "0.1.51"
-futures = "0.3.0"
-http = "1.0"
-reqwest = { version = "0.12.0", default-features = false }
+anyhow = "1.0.97"
+async-trait = "0.1.87"
+futures = "0.3.31"
+http = "1.3"
+reqwest = { version = "0.12.14", default-features = false }
 retry-policies = "0.4"
-thiserror = "1.0.61"
-tracing = { version = "0.1.26", optional = true }
+thiserror = "2.0.12"
+tracing = { version = "0.1.41", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 hyper = "1.0"
-tokio = { version = "1.6.0", default-features = false, features = ["time"] }
+tokio = { version = "1.44.0", default-features = false, features = ["time"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasmtimer = "0.4.1"
-getrandom = { version = "0.2.0", features = ["js"] }
+getrandom = { version = "0.3.1", features = ["wasm_js"] }
 
 [dev-dependencies]
-paste = "1.0.0"
-tokio = { version = "1.0.0", features = ["full"] }
-wiremock = "0.6.0"
-futures = "0.3.0"
+paste = "1.0.15"
+tokio = { version = "1.44.0", features = ["full"] }
+wiremock = "0.6.3"
+futures = "0.3.31"

--- a/reqwest-tracing/CHANGELOG.md
+++ b/reqwest-tracing/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.6] - 2025-02-24
 
+### Changed
+- Update reqwest from 0.12.0 to 0.12.14
+- Upgrade cargo dependencies to latest versions
+
+## [0.5.6] - 2025-02-24
+
 ### Added
 - Added support for OpenTelemetry `0.28` ([#215](https://github.com/TrueLayer/reqwest-middleware/pull/215))
 

--- a/reqwest-tracing/CHANGELOG.md
+++ b/reqwest-tracing/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.6] - 2025-02-24
+## [0.5.6] - 2025-03-13
 
 ### Changed
 - Update reqwest from 0.12.0 to 0.12.14

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-tracing"
-version = "0.5.6"
+version = "0.5.7"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Opentracing middleware for reqwest."
@@ -25,14 +25,14 @@ opentelemetry_0_28 = ["opentelemetry_0_28_pkg", "tracing-opentelemetry_0_29_pkg"
 deprecated_attributes = []
 
 [dependencies]
-reqwest-middleware = { version = ">0.3.0, <0.5.0", path = "../reqwest-middleware" }
+reqwest-middleware = { version = ">0.3.0, <0.6.0", path = "../reqwest-middleware" }
 
-anyhow = "1.0.70"
-async-trait = "0.1.51"
-matchit = "0.8.0"
+anyhow = "1.0.97"
+async-trait = "0.1.87"
+matchit = "0.8.6"
 http = "1"
-reqwest = { version = "0.12.0", default-features = false }
-tracing = "0.1.26"
+reqwest = { version = "0.12.14", default-features = false }
+tracing = "0.1.41"
 
 opentelemetry_0_20_pkg = { package = "opentelemetry", version = "0.20.0", optional = true }
 opentelemetry_0_21_pkg = { package = "opentelemetry", version = "0.21.0", optional = true }
@@ -54,13 +54,13 @@ tracing-opentelemetry_0_28_pkg = { package = "tracing-opentelemetry", version = 
 tracing-opentelemetry_0_29_pkg = { package = "tracing-opentelemetry", version = "0.29.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2.0", features = ["js"] }
+getrandom = { version = "0.3.1", features = ["wasm_js"] }
 
 [dev-dependencies]
-tokio = { version = "1.0.0", features = ["macros"] }
+tokio = { version = "1.44.0", features = ["macros"] }
 tracing_subscriber = { package = "tracing-subscriber", version = "0.3.0" }
-wiremock = "0.6.0"
-reqwest = { version = "0.12.0", features = ["rustls-tls"] }
+wiremock = "0.6.3"
+reqwest = { version = "0.12.14", features = ["rustls-tls"] }
 
 opentelemetry_sdk_0_21 = { package = "opentelemetry_sdk", version = "0.21.0", features = ["trace"] }
 opentelemetry_sdk_0_22 = { package = "opentelemetry_sdk", version = "0.22.0", features = ["trace"] }


### PR DESCRIPTION
<!-- Please explain the changes you made -->
Reqwest 0.12.14 introduces a breaking change that removes a deprecated function.
Reqwest-middleware exposes a public function with the same prototype definition that has been removed:
```rust
    pub fn fetch_mode_no_cors(self) -> Self {
        RequestBuilder {
            inner: self.inner.fetch_mode_no_cors(),
            ..self
        }
    }
```
this function above has been removed from `reqwest::RequestBuilder` and was not advised to be used either.
So, I remove this function as well as suggested by `reqwest`

In addition to that, I also upgrade most of the remaining cargo dependencies for each modules. So, we were using really old packages. Migrating them now to latest should ease maintenance and upgrade for future releases.

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CHANGELOG.md
-->
