### PR TITLE
doc: reference reqwest-auth middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,11 @@ for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 </sub>
 
-## Third-party middleware
+## Third-party middlewares
 
 The following third-party middleware use `reqwest-middleware`:
 
+- [`reqwest-auth`](https://github.com/nicolas-vivot/reqwest-auth) - Generic authorization middleware for reqwest.
 - [`reqwest-conditional-middleware`](https://github.com/oxidecomputer/reqwest-conditional-middleware) - Per-request basis middleware
 - [`http-cache`](https://github.com/06chaynes/http-cache) - HTTP caching rules
 - [`reqwest-cache`](https://gitlab.com/famedly/company/backend/libraries/reqwest-cache) - HTTP caching


### PR DESCRIPTION

Add a reference to the [reqwest-auth](https://github.com/nicolas-vivot/reqwest-auth) middleware in the list of third party middlewares.

If you want to understand the motivation behind this new middleware and the [token-source](https://github.com/nicolas-vivot/token-source) crate, have a look at their readme files.


