### PR TITLE
Deprecate `fetch_mode_no_cors` and prepare for release

### DIFF
--- a/reqwest-middleware/CHANGELOG.md
+++ b/reqwest-middleware/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2025-04-08
+
+### Added
+- Deprecated `fetch_mode_no_cors` as it's been deprecated in reqwest.
+
 ## [0.4.1] - 2025-02-24
 
 - Fixed wasm32 by disabling incompatible parts. On that target, `ClientWithMiddleware` is no longer

--- a/reqwest-middleware/Cargo.toml
+++ b/reqwest-middleware/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-middleware"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Wrapper around reqwest to allow for client middleware chains."

--- a/reqwest-middleware/src/client.rs
+++ b/reqwest-middleware/src/client.rs
@@ -527,6 +527,7 @@ impl RequestBuilder {
     /// The [request mode][mdn] will be set to 'no-cors'.
     ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/Request/mode
+    #[deprecated(note = "Deprecated Upstream")]
     pub fn fetch_mode_no_cors(self) -> Self {
         RequestBuilder {
             inner: self.inner.fetch_mode_no_cors(),

--- a/reqwest-retry/src/retryable_strategy.rs
+++ b/reqwest-retry/src/retryable_strategy.rs
@@ -7,10 +7,10 @@ use reqwest_middleware::Error;
 /// A [`RetryableStrategy`] has a single `handler` functions.
 /// The result of calling the request could be:
 /// - [`reqwest::Response`] In case the request has been sent and received correctly
-///     This could however still mean that the server responded with a erroneous response.
-///     For example a HTTP statuscode of 500
+///   This could however still mean that the server responded with a erroneous response.
+///   For example a HTTP statuscode of 500
 /// - [`reqwest_middleware::Error`] In this case the request actually failed.
-///     This could, for example, be caused by a timeout on the connection.
+///   This could, for example, be caused by a timeout on the connection.
 ///
 /// Example:
 ///

--- a/reqwest-tracing/CHANGELOG.md
+++ b/reqwest-tracing/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.7] - 2025-04-08
+
 ### Added
 - Added support for OpenTelemetry `0.29` ([#228](https://github.com/TrueLayer/reqwest-middleware/pull/228))
 

--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reqwest-tracing"
-version = "0.5.6"
+version = "0.5.7"
 authors = ["Rodrigo Gryzinski <rodrigo.gryzinski@truelayer.com>"]
 edition = "2018"
 description = "Opentracing middleware for reqwest."


### PR DESCRIPTION
## Changes in this PR

* Updates changelogs and versions so we can do a release
* Deprecated  `fetch_mode_no_cors `, as proposed in https://github.com/TrueLayer/reqwest-middleware/pull/225
  * Making this change here as that PR has clippy issues and I'm unable to push to that branch. 
* Fix new clippy lints added in rust 1.86