### PR TITLE
Bump thiserror to v2

### DIFF
--- a/reqwest-middleware/CHANGELOG.md
+++ b/reqwest-middleware/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `thiserror` upgraded to 2.0.12
+
 ## [0.4.2] - 2025-04-08
 
 ### Added

--- a/reqwest-middleware/Cargo.toml
+++ b/reqwest-middleware/Cargo.toml
@@ -23,7 +23,7 @@ async-trait = "0.1.51"
 http = "1.0.0"
 reqwest = { version = "0.12.0", default-features = false }
 serde = "1.0.106"
-thiserror = "1.0.21"
+thiserror = "2.0.12"
 tower-service = "0.3.0"
 
 [dev-dependencies]

--- a/reqwest-retry/CHANGELOG.md
+++ b/reqwest-retry/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `thiserror` upgraded to 2.0.12
+
 ## [0.7.0] - 2024-11-08
 
 ### Breaking changes

--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.3.0"
 http = "1.0"
 reqwest = { version = "0.12.0", default-features = false }
 retry-policies = "0.4"
-thiserror = "1.0.61"
+thiserror = "2.0.12"
 tracing = { version = "0.1.26", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]


### PR DESCRIPTION
Bump this error to v2. None of the major version [release notes](https://github.com/dtolnay/thiserror/releases/tag/2.0.0) apply here.
