### PR TITLE
feat: replace std::time with web_time for wasm32-unknown-unknown compatibility

### DIFF
--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -24,6 +24,7 @@ reqwest = { version = "0.12.0", default-features = false }
 retry-policies = "0.4"
 thiserror = "1.0.61"
 tracing = { version = "0.1.26", optional = true }
+web-time = "1.1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 hyper = "1.0"

--- a/reqwest-retry/src/middleware.rs
+++ b/reqwest-retry/src/middleware.rs
@@ -1,5 +1,5 @@
 //! `RetryTransientMiddleware` implements retrying requests on transient errors.
-use std::time::{Duration, SystemTime};
+use web_time::{Duration, SystemTime};
 
 use crate::retryable_strategy::RetryableStrategy;
 use crate::{retryable::Retryable, retryable_strategy::DefaultRetryableStrategy, RetryError};
@@ -34,7 +34,7 @@ macro_rules! log_retry {
 /// runtime that supports them.
 ///
 ///```rust
-///     use std::time::Duration;
+///     use web_time::Duration;
 ///     use reqwest_middleware::ClientBuilder;
 ///     use retry_policies::{RetryDecision, RetryPolicy, Jitter};
 ///     use retry_policies::policies::ExponentialBackoff;

--- a/reqwest-retry/tests/all/retry.rs
+++ b/reqwest-retry/tests/all/retry.rs
@@ -55,8 +55,8 @@ macro_rules! assert_retry_succeeds_inner {
                 .with(RetryTransientMiddleware::new_with_policy(
                     ExponentialBackoff::builder()
                         .retry_bounds(
-                            std::time::Duration::from_millis(30),
-                            std::time::Duration::from_millis(100),
+                            web_time::Duration::from_millis(30),
+                            web_time::Duration::from_millis(100),
                         )
                         .build_with_max_retries(retry_amount),
                 ))
@@ -151,10 +151,10 @@ assert_retry_succeeds!(429, StatusCode::OK);
 assert_no_retry!(431, StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE);
 assert_no_retry!(451, StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS);
 
-pub struct RetryTimeoutResponder(Arc<AtomicU32>, u32, std::time::Duration);
+pub struct RetryTimeoutResponder(Arc<AtomicU32>, u32, web_time::Duration);
 
 impl RetryTimeoutResponder {
-    fn new(retries: u32, initial_timeout: std::time::Duration) -> Self {
+    fn new(retries: u32, initial_timeout: web_time::Duration) -> Self {
         Self(Arc::new(AtomicU32::new(0)), retries, initial_timeout)
     }
 }
@@ -180,7 +180,7 @@ async fn assert_retry_on_request_timeout() {
         .and(path("/foo"))
         .respond_with(RetryTimeoutResponder::new(
             3,
-            std::time::Duration::from_millis(1000),
+            web_time::Duration::from_millis(1000),
         ))
         .expect(2)
         .mount(&server)
@@ -191,8 +191,8 @@ async fn assert_retry_on_request_timeout() {
         .with(RetryTransientMiddleware::new_with_policy(
             ExponentialBackoff::builder()
                 .retry_bounds(
-                    std::time::Duration::from_millis(30),
-                    std::time::Duration::from_millis(100),
+                    web_time::Duration::from_millis(30),
+                    web_time::Duration::from_millis(100),
                 )
                 .build_with_max_retries(3),
         ))
@@ -200,7 +200,7 @@ async fn assert_retry_on_request_timeout() {
 
     let resp = client
         .get(format!("{}/foo", server.uri()))
-        .timeout(std::time::Duration::from_millis(10))
+        .timeout(web_time::Duration::from_millis(10))
         .send()
         .await
         .expect("call failed");
@@ -246,8 +246,8 @@ async fn assert_retry_on_incomplete_message() {
         .with(RetryTransientMiddleware::new_with_policy(
             ExponentialBackoff::builder()
                 .retry_bounds(
-                    std::time::Duration::from_millis(30),
-                    std::time::Duration::from_millis(100),
+                    web_time::Duration::from_millis(30),
+                    web_time::Duration::from_millis(100),
                 )
                 .build_with_max_retries(3),
         ))
@@ -255,7 +255,7 @@ async fn assert_retry_on_incomplete_message() {
 
     let resp = client
         .get(format!("{}/foo", uri))
-        .timeout(std::time::Duration::from_millis(100))
+        .timeout(web_time::Duration::from_millis(100))
         .send()
         .await
         .expect("call failed");
@@ -297,8 +297,8 @@ async fn assert_retry_on_hyper_canceled() {
         .with(RetryTransientMiddleware::new_with_policy(
             ExponentialBackoff::builder()
                 .retry_bounds(
-                    std::time::Duration::from_millis(30),
-                    std::time::Duration::from_millis(100),
+                    web_time::Duration::from_millis(30),
+                    web_time::Duration::from_millis(100),
                 )
                 .build_with_max_retries(3),
         ))
@@ -306,7 +306,7 @@ async fn assert_retry_on_hyper_canceled() {
 
     let resp = client
         .get(format!("{}/foo", uri))
-        .timeout(std::time::Duration::from_millis(100))
+        .timeout(web_time::Duration::from_millis(100))
         .send()
         .await
         .expect("call failed");
@@ -345,8 +345,8 @@ async fn assert_retry_on_connection_reset_by_peer() {
         .with(RetryTransientMiddleware::new_with_policy(
             ExponentialBackoff::builder()
                 .retry_bounds(
-                    std::time::Duration::from_millis(30),
-                    std::time::Duration::from_millis(100),
+                    web_time::Duration::from_millis(30),
+                    web_time::Duration::from_millis(100),
                 )
                 .build_with_max_retries(3),
         ))
@@ -354,7 +354,7 @@ async fn assert_retry_on_connection_reset_by_peer() {
 
     let resp = client
         .get(format!("{}/foo", uri))
-        .timeout(std::time::Duration::from_millis(100))
+        .timeout(web_time::Duration::from_millis(100))
         .send()
         .await
         .expect("call failed");


### PR DESCRIPTION
This pull request updates the `reqwest-retry` crate to replace the usage of `std::time` with the `web-time` crate for handling time-related functionality. This change ensures compatibility with WebAssembly (WASM) environments, where `std::time` is not supported. The modifications span dependency updates, source code adjustments, and test updates.

### Dependency Update:
- **`reqwest-retry/Cargo.toml`**: Added `web-time = "1.1.0"` as a dependency to replace `std::time`.

### Code Changes:
- **`reqwest-retry/src/middleware.rs`**: Replaced imports of `std::time::{Duration, SystemTime}` with `web_time::{Duration, SystemTime}` across the middleware implementation.
- **`macro_rules! log_retry` in `reqwest-retry/src/middleware.rs`**: Updated example code comments to use `web_time::Duration` instead of `std::time::Duration`.

### Test Updates:
- **`reqwest-retry/tests/all/retry.rs`**:
  - Replaced `std::time::Duration` with `web_time::Duration` in multiple test functions (`assert_retry_succeeds_inner`, `assert_retry_on_request_timeout`, `assert_retry_on_incomplete_message`, `assert_retry_on_hyper_canceled`, `assert_retry_on_connection_reset_by_peer`). This ensures compatibility with the new dependency. [[1]](diffhunk://#diff-14854d70f2a54c312850f7e2775aadafd81b0e6e72e3d80353c891dd63b0946eL58-R59) [[2]](diffhunk://#diff-14854d70f2a54c312850f7e2775aadafd81b0e6e72e3d80353c891dd63b0946eL154-R157) [[3]](diffhunk://#diff-14854d70f2a54c312850f7e2775aadafd81b0e6e72e3d80353c891dd63b0946eL183-R183) [[4]](diffhunk://#diff-14854d70f2a54c312850f7e2775aadafd81b0e6e72e3d80353c891dd63b0946eL194-R203) [[5]](diffhunk://#diff-14854d70f2a54c312850f7e2775aadafd81b0e6e72e3d80353c891dd63b0946eL249-R258) [[6]](diffhunk://#diff-14854d70f2a54c312850f7e2775aadafd81b0e6e72e3d80353c891dd63b0946eL300-R309) [[7]](diffhunk://#diff-14854d70f2a54c312850f7e2775aadafd81b0e6e72e3d80353c891dd63b0946eL348-R357)
  - Updated the `RetryTimeoutResponder` struct and its `new` method to use `web_time::Duration` instead of `std::time::Duration`.

## It works on my machine

I have already tested that this fix works on my project, by refering git url and rev hash directly.
https://github.com/Dicklessgreat/reqwest-middleware/tree/refer-my-retry-policies

## Draft
This PR is draft till the underlying PR is merged https://github.com/TrueLayer/retry-policies/pull/29