### PR TITLE
Update thiserror to 2.0

### DIFF
--- a/reqwest-middleware/CHANGELOG.md
+++ b/reqwest-middleware/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated `thiserror` to `2.0`
+
 ## [0.4.2] - 2025-04-08
 
 ### Added

--- a/reqwest-middleware/Cargo.toml
+++ b/reqwest-middleware/Cargo.toml
@@ -23,7 +23,7 @@ async-trait = "0.1.51"
 http = "1.0.0"
 reqwest = { version = "0.12.0", default-features = false }
 serde = "1.0.106"
-thiserror = "1.0.21"
+thiserror = "2.0"
 tower-service = "0.3.0"
 
 [dev-dependencies]

--- a/reqwest-retry/CHANGELOG.md
+++ b/reqwest-retry/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated `thiserror` to `2.0`
+
 ## [0.7.0] - 2024-11-08
 
 ### Breaking changes

--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.3.0"
 http = "1.0"
 reqwest = { version = "0.12.0", default-features = false }
 retry-policies = "0.4"
-thiserror = "1.0.61"
+thiserror = "2.0"
 tracing = { version = "0.1.26", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/reqwest-retry/tests/all/helpers/simple_server.rs
+++ b/reqwest-retry/tests/all/helpers/simple_server.rs
@@ -126,7 +126,7 @@ impl SimpleServer {
 
     /// Parses the request line and checks that it contains the method, uri and http_version parts.
     /// It does not check if the content of the checked parts is correct. It just checks the format (it contains enough parts) of the request.
-    fn parse_request_line(request: &str) -> Result<Request, Box<dyn Error>> {
+    fn parse_request_line(request: &str) -> Result<Request<'_>, Box<dyn Error>> {
         let mut parts = request.split_whitespace();
 
         let method = parts.next().ok_or("Method not specified")?;


### PR DESCRIPTION
What it says on the tin.

We've moved all our internal crates to thiserror 2.0, but we're still compiling 1.0.21 because of this crate. It would be nice if we could get away from it, if possible.