### PR TITLE
reqwest-retry: allow setting a custom log level with a custom strategy

### DIFF
--- a/reqwest-retry/CHANGELOG.md
+++ b/reqwest-retry/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated `reqwest` to `0.13`
 
+### Added
+- Added `with_retry_log_level` to `RetryTransientMiddleware` with custom `RetryableStrategy` in reqwest-retry
+
 ## [0.8.0] - 2025-11-26
 
 ### Breaking Changes

--- a/reqwest-retry/src/middleware.rs
+++ b/reqwest-retry/src/middleware.rs
@@ -79,14 +79,6 @@ impl<T: RetryPolicy + Send + Sync> RetryTransientMiddleware<T, DefaultRetryableS
     pub fn new_with_policy(retry_policy: T) -> Self {
         Self::new_with_policy_and_strategy(retry_policy, DefaultRetryableStrategy)
     }
-
-    /// Set the log [level][tracing::Level] for retry events.
-    /// The default is [`WARN`][tracing::Level::WARN].
-    #[cfg(feature = "tracing")]
-    pub fn with_retry_log_level(mut self, level: tracing::Level) -> Self {
-        self.retry_log_level = level;
-        self
-    }
 }
 
 impl<T, R> RetryTransientMiddleware<T, R>
@@ -102,6 +94,14 @@ where
             #[cfg(feature = "tracing")]
             retry_log_level: tracing::Level::WARN,
         }
+    }
+
+    /// Set the log [level][tracing::Level] for retry events.
+    /// The default is [`WARN`][tracing::Level::WARN].
+    #[cfg(feature = "tracing")]
+    pub fn with_retry_log_level(mut self, level: tracing::Level) -> Self {
+        self.retry_log_level = level;
+        self
     }
 }
 


### PR DESCRIPTION
<!-- Please explain the changes you made -->

 Fix #251 

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CHANGELOG.md
-->
