### PR TITLE
reqwest-tracing: add method for handling cancelled requests

### DIFF
--- a/reqwest-tracing/CHANGELOG.md
+++ b/reqwest-tracing/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- New method on `ReqwestOtelSpanBackend` for when the request does not finish and is cancelled instead. This happens when the request future is dropped instead of polling it to completion.
+
 ## [0.5.2] - 2024-07-15
 
 ### Added

--- a/reqwest-tracing/src/reqwest_otel_span_builder.rs
+++ b/reqwest-tracing/src/reqwest_otel_span_builder.rs
@@ -67,6 +67,11 @@ pub trait ReqwestOtelSpanBackend {
 
     /// Runs after the request call has executed.
     fn on_request_end(span: &Span, outcome: &Result<Response>, extension: &mut Extensions);
+
+    /// Runs if the request was cancelled before finishing.
+    fn on_request_cancelled(span: &Span) {
+        default_on_request_cancelled(span);
+    }
 }
 
 /// Populates default success/failure fields for a given [`reqwest_otel_span!`] span.
@@ -76,6 +81,11 @@ pub fn default_on_request_end(span: &Span, outcome: &Result<Response>) {
         Ok(res) => default_on_request_success(span, res),
         Err(err) => default_on_request_failure(span, err),
     }
+}
+
+#[inline]
+pub fn default_on_request_cancelled(span: &Span) {
+    span.record(OTEL_STATUS_CODE, "ERROR");
 }
 
 /// Populates default success fields for a given [`reqwest_otel_span!`] span.
@@ -148,6 +158,10 @@ impl ReqwestOtelSpanBackend for DefaultSpanBackend {
     fn on_request_end(span: &Span, outcome: &Result<Response>, _: &mut Extensions) {
         default_on_request_end(span, outcome)
     }
+
+    fn on_request_cancelled(span: &Span) {
+        default_on_request_cancelled(span);
+    }
 }
 
 /// Similar to [`DefaultSpanBackend`] but also adds the `url.full` attribute to request spans.
@@ -163,6 +177,10 @@ impl ReqwestOtelSpanBackend for SpanBackendWithUrl {
 
     fn on_request_end(span: &Span, outcome: &Result<Response>, _: &mut Extensions) {
         default_on_request_end(span, outcome)
+    }
+
+    fn on_request_cancelled(span: &Span) {
+        default_on_request_cancelled(span);
     }
 }
 


### PR DESCRIPTION
## Motivation

When a request is created and possibly partially sent, but the future is dropped before being polled to completion, then `on_request_end` is not called.

## Solution

This adds another method for this scenario so that either `on_request_end` or `on_request_cancelled` is always called if the middleware finishes.

The method has a provided implementation so that it is not a breaking change.

This new method is different from the other two in that it does not take `&mut Extensions`. This is due to technical difficulities as I would need to keep the mutable reference in the drop guard, but at the same time the future that has access to the same mutable reference would be run. I don't think there is a way to solve this without unsafe and raw pointers (or maybe self-referential structs). So I've decided not to provide the extensions instead.

## Alternatives

- We can add another case to the `Error` enum for this and reuse `on_request_end`. This would also force us to solve the issue around the `&mut Extensions` so I think this would also require unsafe code.

