### PR TITLE
chore(deps)!: upgrade `retry-policy` to `0.5`

### DIFF
--- a/reqwest-retry/CHANGELOG.md
+++ b/reqwest-retry/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- Updated `retry-policies` (re-exported as `reqwest_retry::policies`) to 0.5.
+
 ### Changed
 
 - Updated `thiserror` to `2.0`

--- a/reqwest-retry/Cargo.toml
+++ b/reqwest-retry/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = "0.1.51"
 futures = "0.3.0"
 http = "1.0"
 reqwest = { version = "0.12.0", default-features = false }
-retry-policies = "0.4"
+retry-policies = "0.5"
 thiserror = "2.0"
 tracing = { version = "0.1.26", optional = true }
 


### PR DESCRIPTION
Same and closes https://github.com/TrueLayer/reqwest-middleware/pull/233. Just re-running CI so it's mergeable.