### PR TITLE
Set changelog version for last release

### DIFF
--- a/reqwest-middleware/CHANGELOG.md
+++ b/reqwest-middleware/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0] - 2026-01-07
 
 ### Changed
 

--- a/reqwest-retry/CHANGELOG.md
+++ b/reqwest-retry/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.0] - 2026-01-07
 
 ### Changed
 

--- a/reqwest-tracing/CHANGELOG.md
+++ b/reqwest-tracing/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [0.6.0] - 2026-01-07
 
 ### Changed
 


### PR DESCRIPTION
This pull request updates the changelogs for three crates to denote the new releases, specifying the version numbers and release dates.

Changelog updates:

* Updated `reqwest-middleware/CHANGELOG.md` to set the next release version to `0.5.0` with a release date of `2026-01-07`, replacing the "Unreleased" section.
* Updated `reqwest-retry/CHANGELOG.md` to set the next release version to `0.9.0` with a release date of `2026-01-07`, replacing the "Unreleased" section.
* Updated `reqwest-tracing/CHANGELOG.md` to set the next release version to `0.6.0` with a release date of `2026-01-07`, replacing the "Unreleased" section.