### PR TITLE
feat: support opentelemetry 0.32

### DIFF
--- a/reqwest-tracing/Cargo.toml
+++ b/reqwest-tracing/Cargo.toml
@@ -22,6 +22,7 @@ opentelemetry_0_28 = ["opentelemetry_0_28_pkg", "tracing-opentelemetry_0_29_pkg"
 opentelemetry_0_29 = ["opentelemetry_0_29_pkg", "tracing-opentelemetry_0_30_pkg"]
 opentelemetry_0_30 = ["opentelemetry_0_30_pkg", "tracing-opentelemetry_0_31_pkg"]
 opentelemetry_0_31 = ["opentelemetry_0_31_pkg", "tracing-opentelemetry_0_32_pkg"]
+opentelemetry_0_32 = ["opentelemetry_0_32_pkg", "tracing-opentelemetry_0_33_pkg"]
 # This feature ensures that both the old (deprecated) and new attributes are published simultaneously.
 # By doing so, we maintain backward compatibility, allowing existing code that relies on the old attributes
 # to continue functioning while encouraging the transition to the new attributes.
@@ -49,6 +50,7 @@ opentelemetry_0_28_pkg = { package = "opentelemetry", version = "0.28.0", option
 opentelemetry_0_29_pkg = { package = "opentelemetry", version = "0.29.0", optional = true }
 opentelemetry_0_30_pkg = { package = "opentelemetry", version = "0.30.0", optional = true }
 opentelemetry_0_31_pkg = { package = "opentelemetry", version = "0.31.0", optional = true }
+opentelemetry_0_32_pkg = { package = "opentelemetry", version = "0.32.0", optional = true }
 tracing-opentelemetry_0_21_pkg = { package = "tracing-opentelemetry", version = "0.21.0", optional = true }
 tracing-opentelemetry_0_22_pkg = { package = "tracing-opentelemetry", version = "0.22.0", optional = true }
 tracing-opentelemetry_0_23_pkg = { package = "tracing-opentelemetry", version = "0.23.0", optional = true }
@@ -61,6 +63,7 @@ tracing-opentelemetry_0_29_pkg = { package = "tracing-opentelemetry", version = 
 tracing-opentelemetry_0_30_pkg = { package = "tracing-opentelemetry", version = "0.30.0", optional = true }
 tracing-opentelemetry_0_31_pkg = { package = "tracing-opentelemetry", version = "0.31.0", optional = true }
 tracing-opentelemetry_0_32_pkg = { package = "tracing-opentelemetry", version = "0.32.0", optional = true }
+tracing-opentelemetry_0_33_pkg = { package = "tracing-opentelemetry", version = "0.33.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.0", features = ["js"] }
@@ -82,6 +85,7 @@ opentelemetry_sdk_0_28 = { package = "opentelemetry_sdk", version = "0.28.0", fe
 opentelemetry_sdk_0_29 = { package = "opentelemetry_sdk", version = "0.29.0", features = ["trace"] }
 opentelemetry_sdk_0_30 = { package = "opentelemetry_sdk", version = "0.30.0", features = ["trace"] }
 opentelemetry_sdk_0_31 = { package = "opentelemetry_sdk", version = "0.31.0", features = ["trace"] }
+opentelemetry_sdk_0_32 = { package = "opentelemetry_sdk", version = "0.32.0", features = ["trace"] }
 opentelemetry_stdout_0_1 = { package = "opentelemetry-stdout", version = "0.1.0", features = ["trace"] }
 opentelemetry_stdout_0_2 = { package = "opentelemetry-stdout", version = "0.2.0", features = ["trace"] }
 opentelemetry_stdout_0_3 = { package = "opentelemetry-stdout", version = "0.3.0", features = ["trace"] }

--- a/reqwest-tracing/README.md
+++ b/reqwest-tracing/README.md
@@ -99,7 +99,7 @@ an opentelemetry version feature:
 reqwest-tracing = { version = "0.6.0", features = ["opentelemetry_0_22"] }
 ```
 
-Available opentelemetry features are `opentelemetry_0_20` through `opentelemetry_0_31`.
+Available opentelemetry features are `opentelemetry_0_20` through `opentelemetry_0_32`.
 
 #### License
 

--- a/reqwest-tracing/src/lib.rs
+++ b/reqwest-tracing/src/lib.rs
@@ -96,6 +96,7 @@ mod middleware;
     feature = "opentelemetry_0_29",
     feature = "opentelemetry_0_30",
     feature = "opentelemetry_0_31",
+    feature = "opentelemetry_0_32",
 ))]
 mod otel;
 mod reqwest_otel_span_builder;

--- a/reqwest-tracing/src/middleware.rs
+++ b/reqwest-tracing/src/middleware.rs
@@ -58,6 +58,7 @@ where
                 feature = "opentelemetry_0_29",
                 feature = "opentelemetry_0_30",
                 feature = "opentelemetry_0_31",
+                feature = "opentelemetry_0_32",
             ))]
             let req = if extensions.get::<crate::DisableOtelPropagation>().is_none() {
                 // Adds tracing headers to the given request to propagate the OpenTelemetry context to downstream revivers of the request.

--- a/reqwest-tracing/src/otel.rs
+++ b/reqwest-tracing/src/otel.rs
@@ -89,6 +89,13 @@ pub fn inject_opentelemetry_context_into_request(mut request: Request) -> Reques
         injector.inject_context(&context, &mut RequestCarrier::new(&mut request))
     });
 
+    #[cfg(feature = "opentelemetry_0_32")]
+    opentelemetry_0_32_pkg::global::get_text_map_propagator(|injector| {
+        use tracing_opentelemetry_0_33_pkg::OpenTelemetrySpanExt;
+        let context = Span::current().context();
+        injector.inject_context(&context, &mut RequestCarrier::new(&mut request))
+    });
+
     request
 }
 
@@ -195,6 +202,13 @@ impl opentelemetry_0_30_pkg::propagation::Injector for RequestCarrier<'_> {
 
 #[cfg(feature = "opentelemetry_0_31")]
 impl opentelemetry_0_31_pkg::propagation::Injector for RequestCarrier<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        self.set_inner(key, value)
+    }
+}
+
+#[cfg(feature = "opentelemetry_0_32")]
+impl opentelemetry_0_32_pkg::propagation::Injector for RequestCarrier<'_> {
     fn set(&mut self, key: &str, value: String) {
         self.set_inner(key, value)
     }
@@ -444,6 +458,22 @@ mod test {
                 );
 
                 let telemetry = tracing_opentelemetry_0_32_pkg::layer().with_tracer(tracer);
+                subscriber.with(telemetry)
+            };
+
+            #[cfg(feature = "opentelemetry_0_32")]
+            let subscriber = {
+                use opentelemetry_0_32_pkg::trace::TracerProvider;
+
+                let provider = opentelemetry_sdk_0_32::trace::SdkTracerProvider::builder().build();
+
+                let tracer = provider.tracer("reqwest");
+                opentelemetry_0_32_pkg::global::set_tracer_provider(provider);
+                opentelemetry_0_32_pkg::global::set_text_map_propagator(
+                    opentelemetry_sdk_0_32::propagation::TraceContextPropagator::new(),
+                );
+
+                let telemetry = tracing_opentelemetry_0_33_pkg::layer().with_tracer(tracer);
                 subscriber.with(telemetry)
             };
 


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/reqwest-middleware/blob/main/CHANGELOG.md
-->

# Add support for the [latest](https://github.com/open-telemetry/opentelemetry-rust/releases/tag/opentelemetry-0.32.0) OTel release (0.32)

## Testing 
ran `cargo test -all` and `cargo test --features opentelemetry_0_32`. Both are passing

## Caveats
I did not update the changelog. It seems this is now automated with `release-plz`